### PR TITLE
Clean up: consolidate licenses, remove partner skills, add security docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "name": "moonpay-agent-skills",
   "owner": {
-    "name": "Kevin Arifin",
-    "email": "karifin@moonpay.com"
+    "name": "MoonPay",
+    "email": "dev@moonpay.com"
   },
   "metadata": {
     "description": "MoonPay skills for AI agents",


### PR DESCRIPTION
## Summary
- Remove per-skill `LICENSE.txt` files in favor of a single root `LICENSE`
- Remove partner skills (corbits, dune, shipp, yield) from the repo
- Add `CLAUDE.md`, `SECURITY.md`, and Trufflehog secret scanning workflow
- Update marketplace owner to MoonPay org (`dev@moonpay.com`)

## Test plan
- [ ] Verify root `LICENSE` covers all skills correctly
- [ ] Confirm marketplace.json is valid and lists only core skills
- [ ] Confirm Trufflehog workflow runs on push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)