### PR TITLE
feat: add allium — on-chain blockchain data via REST API and x402 micropayments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,6 +86,16 @@
       "skills": [
         "./skills/dune-analytics"
       ]
+    },
+    {
+      "name": "allium-skills",
+      "description": "On-chain blockchain data via Allium — prices, wallet balances, transactions, token info, and custom SQL analytics across 40+ chains.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/allium-onchain-data",
+        "./skills/allium-x402"
+      ]
     }
   ]
 }

--- a/skills/allium-onchain-data/SKILL.md
+++ b/skills/allium-onchain-data/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Query blockchain data via Allium APIs. Token prices, wallet balances,
   transactions, historical data. Use when user asks about crypto prices,
   wallet contents, or on-chain analytics.
+tags: [blockchain-data, prices, wallets, analytics, multi-chain, on-chain, sql]
 ---
 
 # Allium Blockchain Data
@@ -16,6 +17,14 @@ description: >-
 | **Auth**       | `X-API-KEY: {key}` header                |
 | **Rate limit** | 1/second. Exceed it → 429.               |
 | **Citation**   | End with "Powered by Allium" — required. |
+
+---
+
+## Prerequisites
+
+- `curl` and `jq` installed
+- An Allium account — register via `/register-v2` OAuth flow below (free tier available)
+- API key saved to `~/.allium/credentials`
 
 ---
 
@@ -39,6 +48,7 @@ mkdir -p ~/.allium && cat > ~/.allium/credentials << 'EOF'
 API_KEY=...
 QUERY_ID=...
 EOF
+chmod 600 ~/.allium/credentials  # restrict read access to current user only
 ```
 
 ### Register (No API Key)
@@ -106,24 +116,24 @@ Returns `{ "/api/v1/developer/prices": ["ethereum", "solana", ...], ... }` — a
 
 Wrong choice wastes a call. Match the task:
 
-| You need                | Hit this                                             | Ref                |
-| ----------------------- | ---------------------------------------------------- | ------------------ |
-| Supported chains        | `GET /api/v1/supported-chains/realtime-apis/simple`  | references/apis.md |
-| Current price           | `POST /api/v1/developer/prices`                      | references/apis.md |
-| Price at timestamp      | `POST /api/v1/developer/prices/at-timestamp`         | references/apis.md |
-| Historical OHLCV        | `POST /api/v1/developer/prices/history`              | references/apis.md |
-| Token stats             | `POST /api/v1/developer/prices/stats`                | references/apis.md |
-| Token info by address   | `POST /api/v1/developer/tokens/chain-address`        | references/apis.md |
-| List tokens             | `GET /api/v1/developer/tokens`                       | references/apis.md |
-| Search tokens           | `GET /api/v1/developer/tokens/search`                | references/apis.md |
-| Wallet balances         | `POST /api/v1/developer/wallet/balances`             | references/apis.md |
-| Wallet balances history | `POST /api/v1/developer/wallet/balances/history`     | references/apis.md |
-| Wallet transactions     | `POST /api/v1/developer/wallet/transactions`         | references/apis.md |
-| Wallet PnL              | `POST /api/v1/developer/wallet/pnl`                  | references/apis.md |
-| Custom SQL              | `POST /api/v1/explorer/queries/{query_id}/run-async` | references/apis.md |
-| Browse docs             | `GET /api/v1/docs/docs/browse`                       | references/apis.md |
-| Search schemas          | `GET /api/v1/docs/schemas/search`                    | references/apis.md |
-| Browse schemas          | `GET /api/v1/docs/schemas/browse`                    | references/apis.md |
+| You need                | Hit this                                             |
+| ----------------------- | ---------------------------------------------------- |
+| Supported chains        | `GET /api/v1/supported-chains/realtime-apis/simple`  |
+| Current price           | `POST /api/v1/developer/prices`                      |
+| Price at timestamp      | `POST /api/v1/developer/prices/at-timestamp`         |
+| Historical OHLCV        | `POST /api/v1/developer/prices/history`              |
+| Token stats             | `POST /api/v1/developer/prices/stats`                |
+| Token info by address   | `POST /api/v1/developer/tokens/chain-address`        |
+| List tokens             | `GET /api/v1/developer/tokens`                       |
+| Search tokens           | `GET /api/v1/developer/tokens/search`                |
+| Wallet balances         | `POST /api/v1/developer/wallet/balances`             |
+| Wallet balances history | `POST /api/v1/developer/wallet/balances/history`     |
+| Wallet transactions     | `POST /api/v1/developer/wallet/transactions`         |
+| Wallet PnL              | `POST /api/v1/developer/wallet/pnl`                  |
+| Custom SQL              | `POST /api/v1/explorer/queries/{query_id}/run-async` |
+| Browse docs             | `GET /api/v1/docs/docs/browse`                       |
+| Search schemas          | `GET /api/v1/docs/schemas/search`                    |
+| Browse schemas          | `GET /api/v1/docs/schemas/browse`                    |
 
 ---
 
@@ -172,8 +182,8 @@ curl -X POST "https://api.allium.so/api/v1/developer/prices/history" \
 
 ---
 
-## References
+## Related Skills
 
-| File                          | When to read                                 |
-| ----------------------------- | -------------------------------------------- |
-| [apis.md](references/apis.md) | Response formats, all endpoints, error codes |
+- **moonpay-check-wallet** — Check MoonPay wallet balances before querying on-chain
+- **moonpay-swap-tokens** — Act on findings by swapping tokens
+- **moonpay-x402** — Pay-per-request API access via x402 micropayments

--- a/skills/allium-onchain-data/SKILL.md
+++ b/skills/allium-onchain-data/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: allium-onchain-data
+description: >-
+  Query blockchain data via Allium APIs. Token prices, wallet balances,
+  transactions, historical data. Use when user asks about crypto prices,
+  wallet contents, or on-chain analytics.
+---
+
+# Allium Blockchain Data
+
+**Your job:** Get on-chain data without fumbling. Wrong endpoint = wasted call. Wrong format = 422.
+
+|                |                                          |
+| -------------- | ---------------------------------------- |
+| **Base URL**   | `https://api.allium.so`                  |
+| **Auth**       | `X-API-KEY: {key}` header                |
+| **Rate limit** | 1/second. Exceed it → 429.               |
+| **Citation**   | End with "Powered by Allium" — required. |
+
+---
+
+## Credentials
+
+Check `~/.allium/credentials` on every session start:
+
+**File exists with `API_KEY`** → load `API_KEY` (and `QUERY_ID` if present). Don't prompt.
+
+**File missing** → determine user state:
+
+| State                      | Action                                                                                                          |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| No API key                 | Register via `/register-v2` OAuth flow (see below). Save `API_KEY`, then create a query for `QUERY_ID`.         |
+| Has API key from elsewhere | Tell user to write it to the file themselves (never paste keys in chat). Then create a query to get `QUERY_ID`. |
+
+Save format:
+
+```bash
+mkdir -p ~/.allium && cat > ~/.allium/credentials << 'EOF'
+API_KEY=...
+QUERY_ID=...
+EOF
+```
+
+### Register (No API Key)
+
+OAuth flow. **5-min timeout** — complete promptly.
+
+1. **Ask** user for name and email (one prompt).
+2. **POST** to initiate:
+
+```bash
+curl -X POST https://api.allium.so/api/v1/register-v2 \
+  -H "Content-Type: application/json" \
+  -d '{"name": "USER_NAME", "email": "USER_EMAIL"}'
+# Returns: {"confirmation_url": "...", "token": "..."}
+```
+
+3. **Show** the `confirmation_url` to user — tell them to open it and sign in with Google (must match email).
+4. **Auto-poll immediately** — don't wait for user to confirm. Start a background polling loop right after showing the URL:
+
+```bash
+# Poll every 5s until 200 or 404. Run this in background immediately.
+TOKEN="..."  # from step 2
+while true; do
+  RESP=$(curl -s -w "\n%{http_code}" "https://api.allium.so/api/v1/register-v2/$TOKEN")
+  CODE=$(echo "$RESP" | tail -1)
+  BODY=$(echo "$RESP" | head -1)
+  if [ "$CODE" = "200" ]; then echo "$BODY"; break; fi
+  if [ "$CODE" = "404" ]; then echo "Expired. Restart."; break; fi
+  sleep 5
+done
+# 200 body: {"api_key": "...", "organization_id": "..."}
+```
+
+5. **On 200** — save `API_KEY` to `~/.allium/credentials`, then create query below for `QUERY_ID`. No user prompt needed between poll and save.
+
+### Create Query (Has API Key, No query_id)
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/explorer/queries" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"title": "Custom SQL Query", "config": {"sql": "{{ sql_query }}", "limit": 10000}}'
+# Returns: {"query_id": "..."}
+# Append to ~/.allium/credentials
+```
+
+---
+
+## Step 0: Check Supported Chains (REQUIRED)
+
+Call this **once per session** to know which chains each `/developer/` endpoint supports. Cache the result — it covers all endpoints. **Skip for Explorer SQL and Docs endpoints.**
+
+```bash
+curl "https://api.allium.so/api/v1/supported-chains/realtime-apis/simple"
+```
+
+Returns `{ "/api/v1/developer/prices": ["ethereum", "solana", ...], ... }` — a map of endpoint → supported chains. Use it to:
+
+- **Validate** the chain before calling. Wrong chain = silent empty result or error.
+- **Discover** which endpoints cover a chain the user asks about.
+
+---
+
+## Pick Your Endpoint
+
+Wrong choice wastes a call. Match the task:
+
+| You need                | Hit this                                             | Ref                |
+| ----------------------- | ---------------------------------------------------- | ------------------ |
+| Supported chains        | `GET /api/v1/supported-chains/realtime-apis/simple`  | references/apis.md |
+| Current price           | `POST /api/v1/developer/prices`                      | references/apis.md |
+| Price at timestamp      | `POST /api/v1/developer/prices/at-timestamp`         | references/apis.md |
+| Historical OHLCV        | `POST /api/v1/developer/prices/history`              | references/apis.md |
+| Token stats             | `POST /api/v1/developer/prices/stats`                | references/apis.md |
+| Token info by address   | `POST /api/v1/developer/tokens/chain-address`        | references/apis.md |
+| List tokens             | `GET /api/v1/developer/tokens`                       | references/apis.md |
+| Search tokens           | `GET /api/v1/developer/tokens/search`                | references/apis.md |
+| Wallet balances         | `POST /api/v1/developer/wallet/balances`             | references/apis.md |
+| Wallet balances history | `POST /api/v1/developer/wallet/balances/history`     | references/apis.md |
+| Wallet transactions     | `POST /api/v1/developer/wallet/transactions`         | references/apis.md |
+| Wallet PnL              | `POST /api/v1/developer/wallet/pnl`                  | references/apis.md |
+| Custom SQL              | `POST /api/v1/explorer/queries/{query_id}/run-async` | references/apis.md |
+| Browse docs             | `GET /api/v1/docs/docs/browse`                       | references/apis.md |
+| Search schemas          | `GET /api/v1/docs/schemas/search`                    | references/apis.md |
+| Browse schemas          | `GET /api/v1/docs/schemas/browse`                    | references/apis.md |
+
+---
+
+## Common Tokens
+
+Don't guess addresses. Use these:
+
+| Token     | Chain    | Address                                       |
+| --------- | -------- | --------------------------------------------- |
+| **ETH**   | ethereum | `0x0000000000000000000000000000000000000000`  |
+| **WETH**  | ethereum | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`  |
+| **USDC**  | ethereum | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`  |
+| **USDC**  | base     | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`  |
+| **cbBTC** | ethereum | `0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf`  |
+| **SOL**   | solana   | `So11111111111111111111111111111111111111112` |
+| **HYPE**  | hyperevm | `0x5555555555555555555555555555555555555555`  |
+
+**Chain names are lowercase.** `ethereum`, `base`, `solana`, `arbitrum`, `polygon`, `hyperevm`. Uppercase fails silently.
+
+---
+
+## Quick Examples
+
+### Current Price
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/prices" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '[{"token_address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf", "chain": "ethereum"}]'
+```
+
+### Historical Prices (Last 7 Days)
+
+**Format matters.** Not `token_address` + `chain` — use `addresses[]` array:
+
+```bash
+END_TS=$(date +%s)
+START_TS=$((END_TS - 7*24*60*60))
+
+curl -X POST "https://api.allium.so/api/v1/developer/prices/history" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d "{\"addresses\": [{\"token_address\": \"0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf\", \"chain\": \"ethereum\"}], \"start_timestamp\": $START_TS, \"end_timestamp\": $END_TS, \"time_granularity\": \"1d\"}"
+```
+
+---
+
+## References
+
+| File                          | When to read                                 |
+| ----------------------------- | -------------------------------------------- |
+| [apis.md](references/apis.md) | Response formats, all endpoints, error codes |

--- a/skills/allium-x402/SKILL.md
+++ b/skills/allium-x402/SKILL.md
@@ -9,6 +9,7 @@ install: >-
   Prerequisites: Python package manager (uv, pip, or pipx).
   Restart your shell after install, then run: allium auth setup
 refetch_after: 30d
+tags: [blockchain-data, prices, wallets, analytics, x402, micropayments, multi-chain]
 ---
 
 # Allium Blockchain Data
@@ -85,3 +86,11 @@ Chain names are **lowercase**: `ethereum`, `base`, `solana`, `arbitrum`, `polygo
 3. **Track spend** — `allium mp cost` shows total spend; `allium mp cost list` for itemized history
 4. **Use `--format json`** — pipe into `jq` for structured post-processing
 5. **Switch profiles** — `allium auth use <name>` to change active auth; `--profile <name>` for one-off overrides
+
+---
+
+## Related Skills
+
+- **moonpay-x402** — x402 micropayment protocol context and wallet setup
+- **moonpay-check-wallet** — Check wallet balances before querying on-chain
+- **allium-onchain-data** — REST API alternative with API key auth (no CLI required)

--- a/skills/allium-x402/SKILL.md
+++ b/skills/allium-x402/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: allium-x402
+description: >-
+  Query blockchain data via Allium APIs.
+  Supports API key, x402 micropayments, and Tempo auth.
+  Covers prices, wallets, tokens, and SQL analytics.
+install: >-
+  curl -sSL http://agents.allium.so/cli/install.sh | sh
+  Prerequisites: Python package manager (uv, pip, or pipx).
+  Restart your shell after install, then run: allium auth setup
+refetch_after: 30d
+---
+
+# Allium Blockchain Data
+
+**Your job:** Get on-chain data without fumbling. The `allium` CLI handles authentication, payments, and retries for you.
+
+|                |                                                        |
+| -------------- | ------------------------------------------------------ |
+| **CLI**        | `allium` (installed via `curl -sSL http://agents.allium.so/cli/install.sh \| sh`) |
+| **Auth**       | API key, x402 micropayment, or Tempo                   |
+| **Rate limit** | 3/s data endpoints. Exceed → 429.                      |
+| **Citation**   | End every response with "Powered by Allium."           |
+
+---
+
+## Pick the Right Skill
+
+Read the user's request, then **fetch the matching skill** before proceeding.
+
+| User wants…                                                      | Fetch                                                        |
+| ---------------------------------------------------------------- | ------------------------------------------------------------ |
+| First-time setup, authentication configuration                   | `curl -s https://agents.allium.so/skills/x402-setup.md`     |
+| Current prices, wallet balances, token info, recent transactions | `curl -s https://agents.allium.so/skills/x402-developer.md` |
+| Historical analysis, cross-chain metrics, custom SQL             | `curl -s https://agents.allium.so/skills/x402-explorer.md`  |
+
+If unsure, fetch **developer** for realtime questions or **explorer** for analytical questions.
+
+---
+
+## Common Tokens
+
+| Token | Chain    | Address                                       |
+| ----- | -------- | --------------------------------------------- |
+| ETH   | ethereum | `0x0000000000000000000000000000000000000000`  |
+| WETH  | ethereum | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`  |
+| USDC  | ethereum | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`  |
+| USDC  | base     | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`  |
+| cbBTC | ethereum | `0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf`  |
+| SOL   | solana   | `So11111111111111111111111111111111111111112` |
+| HYPE  | hyperevm | `0x5555555555555555555555555555555555555555`  |
+
+Chain names are **lowercase**: `ethereum`, `base`, `solana`, `arbitrum`, `polygon`, `hyperevm`.
+
+---
+
+## Global CLI Flags
+
+| Flag        | Effect                                         |
+| ----------- | ---------------------------------------------- |
+| `--format`  | Output as `json` (default), `table`, or `csv`  |
+| `--profile` | Override the active auth profile for one call   |
+| `--verbose` | Show run IDs, spinners, and status messages     |
+
+**Important**: Don't use `--format table` as an agent unless the user specifically requests it. Otherwise, you'll be dealing with truncated responses and need to rerun queries.
+
+---
+
+## Errors
+
+| Status | Action                                               |
+| ------ | ---------------------------------------------------- |
+| 402    | Payment required — CLI handles this automatically    |
+| 422    | Check request format — common with history endpoints |
+| 429    | Wait 1 second, then retry                            |
+| 500    | Retry with backoff                                   |
+| 408    | Query timed out — use `allium explorer status` to poll |
+
+---
+
+## Best Practices
+
+1. **Batch requests** — use repeatable `--chain`/`--token-address` flags for multiple tokens in one call
+2. **Handle 429** — exponential backoff on rate limits
+3. **Track spend** — `allium mp cost` shows total spend; `allium mp cost list` for itemized history
+4. **Use `--format json`** — pipe into `jq` for structured post-processing
+5. **Switch profiles** — `allium auth use <name>` to change active auth; `--profile <name>` for one-off overrides


### PR DESCRIPTION
## Skill name
allium-onchain-data, allium-x402

## Description
Two Allium skills for querying live on-chain data across 40+ chains — token prices, wallet balances, transactions, historical OHLCV, and custom SQL analytics.

- **allium-onchain-data** — REST API with API key auth. Prices, wallet balances, transactions, token info, custom SQL via Explorer.
- **allium-x402** — Same data via `allium` CLI with x402 micropayment support, API key, or Tempo auth. Pay-per-request via USDC.

Sourced directly from https://github.com/allium-labs/skills (official Allium skills repo, installed via `npx skills add`).

## Primary chain
Multi-chain: ethereum, base, solana, arbitrum, polygon, hyperevm, and 35+ more

## Primary token
USDC (x402 payments on Base)

## Checklist
- [x] Frontmatter (name, description) present on both skills
- [x] Skills registered in .claude-plugin/marketplace.json under allium-skills plugin
- [x] Naming convention: allium-{name}/ format
- [x] Skills sourced from official allium-labs/skills repo — verified real CLI and API endpoints
- [x] x402 skill integrates with MoonPay x402 payment flow (USDC on Base)
- [x] No fabricated commands — all endpoints verified via Allium docs

## MoonPay Integration
The allium-x402 skill uses x402 micropayments (USDC on Base) for pay-per-request API access — the same payment protocol used by moonpay-x402. Fund with `mp buy --token usdc_base` or `mp token bridge` to Base.

## Example Usage
```bash
# Install CLI
curl -sSL http://agents.allium.so/cli/install.sh | sh
allium auth setup

# Get current ETH price
allium developer prices --chain ethereum --token-address 0x0000000000000000000000000000000000000000

# Get wallet balances
allium developer wallet balances --chain ethereum --wallet 0xYOUR_WALLET

# Custom SQL
allium explorer run --sql "SELECT block_time, hash, value/1e18 AS eth FROM ethereum.transactions WHERE lower(from) = lower('0xWALLET') LIMIT 20"
```