### PR TITLE
feat: add ThoughtProof reasoning verification skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "moonpay-skills",
-      "description": "Crypto infrastructure skills for AI agents — wallet management, token trading, cross-chain bridges, fiat on/off ramp, and more via the MoonPay CLI.",
+      "description": "Crypto infrastructure skills for AI agents \u2014 wallet management, token trading, cross-chain bridges, fiat on/off ramp, and more via the MoonPay CLI.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -35,7 +35,8 @@
         "./skills/moonpay-trading-automation",
         "./skills/moonpay-upgrade",
         "./skills/moonpay-virtual-account",
-        "./skills/moonpay-x402"
+        "./skills/moonpay-x402",
+        "./skills/thoughtproof-reasoning-check"
       ]
     },
     {
@@ -58,7 +59,7 @@
     },
     {
       "name": "messari-skills",
-      "description": "Messari x402 research skills — pay-per-request access to Messari's full API via USDC on Base. Asset data, signals, funding intel, alpha scouting, and AI deep research. No API key required.",
+      "description": "Messari x402 research skills \u2014 pay-per-request access to Messari's full API via USDC on Base. Asset data, signals, funding intel, alpha scouting, and AI deep research. No API key required.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -80,7 +81,7 @@
     },
     {
       "name": "dune-skills",
-      "description": "Blockchain analytics via Dune REST API — DuneSQL queries against live on-chain data",
+      "description": "Blockchain analytics via Dune REST API \u2014 DuneSQL queries against live on-chain data",
       "source": "./",
       "strict": false,
       "skills": [
@@ -89,7 +90,7 @@
     },
     {
       "name": "allium-skills",
-      "description": "On-chain blockchain data via Allium — prices, wallet balances, transactions, token info, and custom SQL analytics across 40+ chains.",
+      "description": "On-chain blockchain data via Allium \u2014 prices, wallet balances, transactions, token info, and custom SQL analytics across 40+ chains.",
       "source": "./",
       "strict": false,
       "skills": [

--- a/skills/thoughtproof-reasoning-check/SKILL.md
+++ b/skills/thoughtproof-reasoning-check/SKILL.md
@@ -97,4 +97,4 @@ For maximum safety before any high-value trade:
 4. moonpay-swap-tokens   → Execute with confidence
 ```
 
-Maiat and ThoughtProof are complementary — Maiat checks the agent's reputation over time, ThoughtProof checks whether this specific decision is well-reasoned right now. Both are needed for full coverage.
+Maiat and ThoughtProof are complementary — Maiat checks the agent's reputation over time, ThoughtProof checks whether this specific decision is well-reasoned right now. Run each step manually or chain them in your agent workflow for full coverage.

--- a/skills/thoughtproof-reasoning-check/SKILL.md
+++ b/skills/thoughtproof-reasoning-check/SKILL.md
@@ -82,15 +82,19 @@ If payment is required first:
 
 ## Related skills
 
-- **maiat-trust-check** — Behavioral trust score (is the agent reliable?)
-- **maiat-token-safety** — Honeypot and rug pull detection (is the token safe?)
-- **moonpay-swap-tokens** — Execute the swap after verification passes
+- **maiat-trust-check** — Behavioral trust score from 29,000+ indexed agents. Run this first — it answers "is this agent reliable based on past behavior?" ThoughtProof then answers "is this specific decision sound?"
+- **maiat-token-safety** — Honeypot and rug pull detection before any token interaction
+- **moonpay-swap-tokens** — Execute the swap after all verification passes
 
-## Stack
+## Recommended stack
 
-Maiat checks trust. ThoughtProof checks reasoning. Together: safe agent commerce.
+For maximum safety before any high-value trade:
 
-1. maiat-trust-check → Is the agent trustworthy?
-2. maiat-token-safety → Is the token safe?
-3. **thoughtproof-reasoning-check → Is the decision well-reasoned?**
-4. moonpay-swap-tokens → Execute with confidence
+```
+1. maiat-trust-check     → Is the agent trustworthy? (behavioral history)
+2. maiat-token-safety    → Is the token safe? (rug/honeypot)
+3. thoughtproof-reasoning-check → Is the decision sound? (reasoning quality)
+4. moonpay-swap-tokens   → Execute with confidence
+```
+
+Maiat and ThoughtProof are complementary — Maiat checks the agent's reputation over time, ThoughtProof checks whether this specific decision is well-reasoned right now. Both are needed for full coverage.

--- a/skills/thoughtproof-reasoning-check/SKILL.md
+++ b/skills/thoughtproof-reasoning-check/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: thoughtproof-reasoning-check
+description: Verify whether an AI agent's decision is well-reasoned before executing. Adversarial multi-model critique (Claude, Grok, DeepSeek) returns ALLOW or HOLD with confidence score. Use before any high-value swap, trade, or autonomous action.
+tags: [verification, reasoning, agents, defi, security]
+---
+
+# ThoughtProof Reasoning Check
+
+## Goal
+
+Before executing a trade or autonomous action, verify that the agent's reasoning is sound. ThoughtProof runs adversarial multi-model critique and returns a signed verdict: ALLOW (reasoning is sound) or HOLD (material defects found).
+
+## Prerequisites
+
+- MoonPay CLI installed: `npm install -g @moonpay/cli`
+- A funded wallet on Base (for x402 payment): `mp wallet create`
+
+## x402 Paid API ($0.008-$1.00 USDC on Base)
+
+Via SDK:
+```bash
+npm install thoughtproof-sdk
+```
+
+```javascript
+const { check } = require('thoughtproof-sdk');
+const result = await check({
+  claim: "Swap $2K USDC to ETH. ETH at $2180, RSI 34.",
+  stakeLevel: "medium",
+  domain: "financial"
+});
+```
+
+## Response
+
+```json
+{
+  "verdict": "ALLOW",
+  "confidence": 0.82,
+  "objections": [],
+  "durationMs": 55000
+}
+```
+
+If payment is required first:
+```json
+{
+  "verdict": "HOLD",
+  "confidence": 0,
+  "paymentRequired": {
+    "amountUsdc": "0.05",
+    "network": "base",
+    "recipientWallet": "0xAB9f84864662f980614bD1453dB9950Ef2b82E83"
+  }
+}
+```
+
+## Decision logic
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| `ALLOW` | Reasoning is sound | Execute the trade |
+| `HOLD` | Material defects found | Do not execute, review reasoning |
+| `UNCERTAIN` | Insufficient evidence | Gather more context |
+| `DISSENT` | Models strongly disagree | Require human review |
+
+## Pricing (stake-proportional)
+
+| Stake Level | Cost | Use case |
+|-------------|------|----------|
+| `low` | $0.008-$0.02 | Routine swaps under $2K |
+| `medium` | $0.02-$0.05 | Standard trades $2K-$10K |
+| `high` | $0.05-$0.15 | Large trades $10K-$25K |
+| `critical` | $0.15-$1.00 | High-value trades over $25K |
+
+## Example workflow
+
+1. User says: "Swap $5K USDC for ETH"
+2. Check reasoning: POST to ThoughtProof with the trade thesis
+3. If `HOLD` or `DISSENT` → warn user, show objections, do not proceed
+4. If `ALLOW` with confidence > 0.60 → execute the swap
+
+## Related skills
+
+- **maiat-trust-check** — Behavioral trust score (is the agent reliable?)
+- **maiat-token-safety** — Honeypot and rug pull detection (is the token safe?)
+- **moonpay-swap-tokens** — Execute the swap after verification passes
+
+## Stack
+
+Maiat checks trust. ThoughtProof checks reasoning. Together: safe agent commerce.
+
+1. maiat-trust-check → Is the agent trustworthy?
+2. maiat-token-safety → Is the token safe?
+3. **thoughtproof-reasoning-check → Is the decision well-reasoned?**
+4. moonpay-swap-tokens → Execute with confidence


### PR DESCRIPTION
## What

New partner skill for reasoning verification before trades execute.

### thoughtproof-reasoning-check
- Adversarial multi-model critique (Claude, Grok, DeepSeek) before any swap or autonomous action
- x402-gated on Base ($0.008-$1.00 USDC, stake-proportional)
- Returns ALLOW/HOLD with confidence score and objections
- SDK: `npm install thoughtproof-sdk`

## Why

Maiat checks trust (is the agent reliable?). ThoughtProof checks reasoning (is this specific decision sound?). Together: safe agent commerce.

Recommended stack:
1. maiat-trust-check → Is the agent trustworthy?
2. maiat-token-safety → Is the token safe?
3. **thoughtproof-reasoning-check → Is the decision well-reasoned?**
4. moonpay-swap-tokens → Execute with confidence

cc @JhiNResH
