### PR TITLE
fix: replace -f flag with --json

### DIFF
--- a/skills/moonpay-price-alerts/SKILL.md
+++ b/skills/moonpay-price-alerts/SKILL.md
@@ -40,7 +40,7 @@ DIRECTION="below"  # "above" or "below"
 SCRIPT_NAME="alert-sol-below-80"
 
 # --- Check price ---
-PRICE=$("$MP" -f compact token retrieve --token "$TOKEN" --chain "$CHAIN" | jq -r '.marketData.price')
+PRICE=$("$MP" --json token search --query "$SYMBOL" --chain "$CHAIN" | jq -r '.items[0].marketData.price')
 
 if [ -z "$PRICE" ] || [ "$PRICE" = "null" ]; then
   log "ALERT $SCRIPT_NAME: price fetch failed, skipping"


### PR DESCRIPTION
Fixes #24 

  ## What
  The `-f` flag (`-f compact`, `-f json`, `-f table`) does
  not exist in `mp` CLI v1.12.4. Every command using it fails
   with `error: unknown option '-f'`. The correct global flag
   is `--json`.

  Additionally, `token retrieve` returns no price data —
  replaced with `token search` which returns
  `.items[0].marketData.price`.

  ## Affected skills
  - `moonpay-trading-automation` — 7 occurrences
  - `moonpay-export-data` — 5 occurrences
  - `moonpay-block-explorer` — 4 occurrences
  - `moonpay-price-alerts` — 1 occurrence
  - `moonpay-prediction-market` — 1 occurrence
  - `moonpay-check-wallet` — 1 occurrence
  
<img width="1346" height="812" alt="Screenshot 2026-03-23 170012" src="https://github.com/user-attachments/assets/84c9859d-7f82-468a-85f0-3963aaad9e89" />
