### PR TITLE
fix: update LICENSE copyright to MoonPay, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Hypermint EU Limited
+Copyright (c) 2026 MoonPay, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update copyright holder from "Hypermint EU Limited" to "MoonPay, Inc."

🤖 Generated with [Claude Code](https://claude.com/claude-code)