### PR TITLE
fix: replace broken -f flag with --json, fix token price fetching

### DIFF
--- a/skills/moonpay-block-explorer/SKILL.md
+++ b/skills/moonpay-block-explorer/SKILL.md
@@ -41,7 +41,7 @@ xdg-open "https://etherscan.io/tx/0xabcd..."
 `mp token swap` and `mp token bridge` return a result with the transaction signature. Use the chain to pick the correct explorer.
 
 ```bash
-RESULT=$(mp -f compact token swap --wallet main --chain solana \
+RESULT=$(mp --json token swap --wallet main --chain solana \
   --from-token EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --from-amount 1 \
   --to-token So11111111111111111111111111111111111111111)
@@ -57,8 +57,8 @@ open "https://solscan.io/tx/$SIG"
 
 ```bash
 # View most recent transaction
-TX=$(mp -f compact transaction list --wallet <addr> | jq -r '.items[0].from.txHash')
-CHAIN=$(mp -f compact transaction list --wallet <addr> | jq -r '.items[0].from.chain')
+TX=$(mp --json transaction list --wallet <addr> | jq -r '.items[0].from.txHash')
+CHAIN=$(mp --json transaction list --wallet <addr> | jq -r '.items[0].from.chain')
 # Build URL from chain → explorer table above
 ```
 
@@ -95,7 +95,7 @@ Get token addresses from: `mp token search --query "USDC" --chain solana`
 `mp buy` returns a checkout URL. Open it directly:
 
 ```bash
-URL=$(mp -f compact buy --token sol --amount 1 --wallet <addr> --email <email> | jq -r '.url')
+URL=$(mp --json buy --token sol --amount 1 --wallet <addr> --email <email> | jq -r '.url')
 open "$URL"
 ```
 

--- a/skills/moonpay-check-wallet/SKILL.md
+++ b/skills/moonpay-check-wallet/SKILL.md
@@ -51,7 +51,7 @@ Bitcoin uses a separate command: `mp bitcoin balance retrieve --wallet <btc-addr
 
 ## Output formats
 
-Use `mp -f table token balance list ...` for a quick table view, or `mp -f json ...` for programmatic processing.
+Use `mp --json token balance list ...` for programmatic processing.
 
 ## Related skills
 

--- a/skills/moonpay-export-data/SKILL.md
+++ b/skills/moonpay-export-data/SKILL.md
@@ -25,7 +25,7 @@ mkdir -p ~/Documents/moonpay
 # Header + data
 echo "symbol,name,amount,usd_value,price" > ~/Documents/moonpay/portfolio-$(date +%Y%m%d).csv
 
-mp -f compact token balance list --wallet <address> --chain solana \
+mp --json token balance list --wallet <address> --chain solana \
   | jq -r '.items[] | [.symbol, .name, .balance.amount, .balance.value, .balance.price] | @csv' \
   >> ~/Documents/moonpay/portfolio-$(date +%Y%m%d).csv
 ```
@@ -39,7 +39,7 @@ FILE=~/Documents/moonpay/portfolio-$(date +%Y%m%d).csv
 echo "chain,symbol,name,amount,usd_value,price" > "$FILE"
 
 for CHAIN in solana ethereum base polygon arbitrum; do
-  mp -f compact token balance list --wallet <address> --chain "$CHAIN" \
+  mp --json token balance list --wallet <address> --chain "$CHAIN" \
     | jq -r --arg chain "$CHAIN" '.items[] | [$chain, .symbol, .name, .balance.amount, .balance.value, .balance.price] | @csv' \
     >> "$FILE" 2>/dev/null
 done
@@ -55,7 +55,7 @@ Export swap and bridge history. These are transactions executed via the CLI and 
 echo "date,type,from_chain,from_token,from_amount,to_chain,to_token,to_amount,usd,status" \
   > ~/Documents/moonpay/transactions-$(date +%Y%m%d).csv
 
-mp -f compact transaction list --wallet <address> \
+mp --json transaction list --wallet <address> \
   | jq -r '.items[] | [
       .transactionId,
       .type,
@@ -70,7 +70,7 @@ mp -f compact transaction list --wallet <address> \
 ### Filter by chain
 
 ```bash
-mp -f compact transaction list --wallet <address> --chain solana \
+mp --json transaction list --wallet <address> --chain solana \
   | jq -r '.items[] | ...' >> transactions.csv
 ```
 
@@ -79,7 +79,7 @@ mp -f compact transaction list --wallet <address> --chain solana \
 For structured data or programmatic use:
 
 ```bash
-mp -f compact token balance list --wallet <address> --chain solana \
+mp --json token balance list --wallet <address> --chain solana \
   | jq '.items | map({symbol, amount: .balance.amount, usd: .balance.value})' \
   > ~/Documents/moonpay/portfolio-$(date +%Y%m%d).json
 ```

--- a/skills/moonpay-prediction-market/SKILL.md
+++ b/skills/moonpay-prediction-market/SKILL.md
@@ -143,7 +143,7 @@ mp prediction-market position sell --wallet main --provider polymarket --tokenId
 
 ## Tips
 
-- Use `mp -f json prediction-market ...` for programmatic output
+- Use `mp --json prediction-market ...` for programmatic output
 - Markets with higher volume and liquidity have tighter spreads
 - Check `acceptingOrders` — closed markets cannot be traded
 - `negRisk` markets use a different settlement framework — the CLI handles this automatically

--- a/skills/moonpay-price-alerts/SKILL.md
+++ b/skills/moonpay-price-alerts/SKILL.md
@@ -8,7 +8,7 @@ tags: [alerts, research]
 
 ## Goal
 
-Monitor token prices and get desktop notifications when they cross a threshold. Uses `mp token retrieve` for price checks and OS notifications (`osascript`/`notify-send`) for alerts. Observe-only — no funds at risk.
+Monitor token prices and get desktop notifications when they cross a threshold. Uses `mp token search` for price checks and OS notifications (`osascript`/`notify-send`) for alerts. Observe-only — no funds at risk.
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ DIRECTION="below"  # "above" or "below"
 SCRIPT_NAME="alert-sol-below-80"
 
 # --- Check price ---
-PRICE=$("$MP" -f compact token retrieve --token "$TOKEN" --chain "$CHAIN" | jq -r '.marketData.price')
+PRICE=$("$MP" --json token search --query "$SYMBOL" --chain "$CHAIN" | jq -r '.items[0].marketData.price')
 
 if [ -z "$PRICE" ] || [ "$PRICE" = "null" ]; then
   log "ALERT $SCRIPT_NAME: price fetch failed, skipping"
@@ -152,7 +152,7 @@ tail -50 ~/.config/moonpay/logs/alerts.log
 
 ## Tips
 
-- Price checks via `mp token retrieve` are free — no gas costs
+- Price checks via `mp token search` are free — no gas costs
 - 5-minute intervals are reasonable; don't go below 1 minute
 - Use `mp token search --query "SOL" --chain solana` to resolve token addresses
 - Alerts log to `~/.config/moonpay/logs/alerts.log` — check this to verify they're running

--- a/skills/moonpay-trading-automation/SKILL.md
+++ b/skills/moonpay-trading-automation/SKILL.md
@@ -40,7 +40,7 @@ AMOUNT=5
 
 # --- Execute ---
 log "SWAP: $AMOUNT $FROM_TOKEN -> $TO_TOKEN on $CHAIN"
-RESULT=$("$MP" -f compact token swap \
+RESULT=$("$MP" --json token swap \
   --wallet "$WALLET" --chain "$CHAIN" \
   --from-token "$FROM_TOKEN" --from-amount "$AMOUNT" \
   --to-token "$TO_TOKEN" 2>&1) || {
@@ -51,7 +51,7 @@ log "OK: $RESULT"
 ```
 
 Key points:
-- `mp -f compact` outputs single-line JSON, ideal for `jq` parsing
+- `mp --json` outputs single-line JSON, ideal for `jq` parsing
 - Use `$(which mp)` and store as `MP` — cron/launchd have minimal PATH
 - Wallet names only in scripts — `mp` handles keychain decryption at runtime
 - If the user gives token names/symbols, resolve to addresses first with `mp token search`
@@ -137,7 +137,7 @@ TARGET_PRICE=80
 SCRIPT_NAME="limit-buy-sol"
 
 # --- Check price ---
-PRICE=$("$MP" -f compact token retrieve --token "$TOKEN" --chain "$CHAIN" | jq -r '.marketData.price')
+PRICE=$("$MP" --json token search --query "$TOKEN" --chain "$CHAIN" | jq -r '.items[0].marketData.price')
 
 if [ -z "$PRICE" ] || [ "$PRICE" = "null" ]; then
   log "LIMIT $SCRIPT_NAME: price fetch failed, skipping"
@@ -147,7 +147,7 @@ fi
 # --- Compare ---
 if (( $(echo "$PRICE < $TARGET_PRICE" | bc -l) )); then
   log "LIMIT $SCRIPT_NAME: price $PRICE < $TARGET_PRICE — executing buy"
-  RESULT=$("$MP" -f compact token swap \
+  RESULT=$("$MP" --json token swap \
     --wallet "$WALLET" --chain "$CHAIN" \
     --from-token "$BUY_WITH" --from-amount "$BUY_AMOUNT" \
     --to-token "$TOKEN" 2>&1) || {
@@ -186,16 +186,16 @@ TRIGGER_PRICE=70
 SCRIPT_NAME="stop-loss-sol"
 
 # --- Check price ---
-PRICE=$("$MP" -f compact token retrieve --token "$SELL_TOKEN" --chain "$CHAIN" | jq -r '.marketData.price')
+PRICE=$("$MP" --json token search --query "$SELL_TOKEN" --chain "$CHAIN" | jq -r '.items[0].marketData.price')
 
 if (( $(echo "$PRICE < $TRIGGER_PRICE" | bc -l) )); then
   # Get current balance to sell all
-  BALANCE=$("$MP" -f compact token balance list --wallet "$WALLET" --chain "$CHAIN" \
+  BALANCE=$("$MP" --json token balance list --wallet "$WALLET" --chain "$CHAIN" \
     | jq -r --arg addr "$SELL_TOKEN" '.items[] | select(.address == $addr) | .balance.amount')
 
   if [ -n "$BALANCE" ] && (( $(echo "$BALANCE > 0" | bc -l) )); then
     log "STOP-LOSS $SCRIPT_NAME: price $PRICE < $TRIGGER_PRICE — selling $BALANCE"
-    RESULT=$("$MP" -f compact token swap \
+    RESULT=$("$MP" --json token swap \
       --wallet "$WALLET" --chain "$CHAIN" \
       --from-token "$SELL_TOKEN" --from-amount "$BALANCE" \
       --to-token "$TO_TOKEN" 2>&1) || {
@@ -262,7 +262,7 @@ fi
 - Check logs after the first run: `tail -20 ~/.config/moonpay/logs/trading.log`
 - Scripts don't contain secrets — `mp` decrypts wallets via OS keychain at runtime
 - The machine must be logged in (user session active) for keychain access to work
-- Price checks via `mp token retrieve` are free; swaps cost gas
+- Price checks via `mp token search` are free; swaps cost gas
 - Limit order checks every 5 minutes is reasonable — don't go below 1 minute
 - Use `bc -l` for decimal price comparison (bash can't compare floats natively)
 - If `bc` isn't available, use: `awk "BEGIN {exit !($PRICE < $TARGET)}"`


### PR DESCRIPTION
## Summary
- Replace all `mp -f compact` / `-f json` / `-f table` with `mp --json` (the `-f` flag doesn't exist in the CLI)
- Fix price fetching: `mp token retrieve` doesn't return marketData/price — use `mp --json token search` instead
- Fixes 6 skills: moonpay-price-alerts, moonpay-export-data, moonpay-block-explorer, moonpay-prediction-market, moonpay-trading-automation, moonpay-check-wallet

Supersedes PR #25 which only fixed 1 of the 6 affected skills.

## Verified
- `mp --json token search --query SOL --chain solana | jq '.items[0].marketData.price'` returns valid price
- `mp --json token balance list`, `mp --json transaction list` all work with `--json` flag
- `mp token retrieve` works for metadata but returns no price data

## Test plan
- [ ] Grep for `-f compact`, `-f json`, `-f table` — should be zero results
- [ ] Price alert and trading automation scripts use `token search` for prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)