### PR TITLE
fix: correct broken CLI commands across 4 skills

### DIFF
--- a/skills/corbits-marketplace/SKILL.md
+++ b/skills/corbits-marketplace/SKILL.md
@@ -119,10 +119,14 @@ mp token swap \
 
 ```bash
 mp virtual-account create
-mp virtual-account kyc submit
-mp virtual-account bank-account add
+mp virtual-account kyc continue
+mp virtual-account bank-account register
 mp virtual-account onramp create \
-  --amount 500 --currency usd --chain ethereum --wallet <evm-address>
+  --name "Corbits Onramp" \
+  --fiat usd \
+  --stablecoin usdc \
+  --wallet <evm-address> \
+  --chain ethereum
 ```
 
 ### Deposit Link (Permissionless)

--- a/skills/moonpay-virtual-account/SKILL.md
+++ b/skills/moonpay-virtual-account/SKILL.md
@@ -139,7 +139,7 @@ mp virtual-account bank-account delete --bankAccountId <id>
 # Create an offramp
 mp virtual-account offramp create \
   --name "My Offramp" \
-  --fiat USD \
+  --bankAccountId <bank-account-id> \
   --stablecoin USDC \
   --chain solana
 

--- a/skills/myriad-prediction-markets/SKILL.md
+++ b/skills/myriad-prediction-markets/SKILL.md
@@ -210,7 +210,10 @@ mp token balance list --wallet <bnb-address> --chain bsc
 
 ```bash
 mp virtual-account offramp create \
-  --amount 200 --chain bsc --wallet <bnb-address>
+  --name "Offramp" \
+  --bankAccountId <bank-account-id> \
+  --stablecoin usdc \
+  --chain bsc
 ```
 
 ## End-to-End Workflow

--- a/skills/shipp-sports-data/SKILL.md
+++ b/skills/shipp-sports-data/SKILL.md
@@ -120,10 +120,13 @@ mp message sign --wallet shipp-sports-agent --chain polygon --message "I own thi
 
 # Withdraw winnings to bank
 mp virtual-account offramp create \
-  --amount 500 --chain polygon --wallet <polygon-address>
+  --name "Offramp" \
+  --bankAccountId <bank-account-id> \
+  --stablecoin usdc \
+  --chain polygon
 
 # Hardware wallet (high security)
-mp wallet add-ledger --name "shipp-sports-ledger"
+mp wallet hardware add --name "shipp-sports-ledger"
 ```
 
 ## Funding Options


### PR DESCRIPTION
## Summary
Fixes incorrect `mp` CLI commands found across 4 skills:
- `kyc submit` → `kyc continue`
- `bank-account add` → `bank-account register`
- `wallet add-ledger` → `wallet hardware add`
- `onramp create`: wrong flags (`--amount`/`--currency` → `--name`/`--fiat`/`--stablecoin`)
- `offramp create`: wrong flags (`--amount`/`--wallet`/`--fiat` → `--name`/`--bankAccountId`/`--stablecoin`)

All replacements verified against `mp` CLI `--help` output. Supersedes #28.

## Test plan
- [ ] Grep for `kyc submit`, `bank-account add`, `add-ledger` — zero results
- [ ] All `onramp create` and `offramp create` use correct flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)