### PR TITLE
fix: update ThoughtProof skill to v2.0 verdicts and MoonPay workflow

### DIFF
--- a/skills/thoughtproof-reasoning-check/SKILL.md
+++ b/skills/thoughtproof-reasoning-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: thoughtproof-reasoning-check
-description: Verify whether an AI agent's decision is well-reasoned before executing. Adversarial multi-model critique (Claude, Grok, DeepSeek) returns ALLOW or HOLD with confidence score. Use before any high-value swap, trade, or autonomous action.
+description: Verify whether an AI agent's decision is well-reasoned before executing. Adversarial multi-model critique (Claude, Grok, DeepSeek) returns ALLOW, BLOCK, or UNCERTAIN with confidence score. Use before any high-value swap, trade, or autonomous action.
 tags: [verification, reasoning, agents, defi, security]
 ---
 
@@ -8,7 +8,7 @@ tags: [verification, reasoning, agents, defi, security]
 
 ## Goal
 
-Before executing a trade or autonomous action, verify that the agent's reasoning is sound. ThoughtProof runs adversarial multi-model critique and returns a signed verdict: ALLOW (reasoning is sound) or HOLD (material defects found).
+Before executing a trade or autonomous action, verify that the agent's reasoning is sound. ThoughtProof runs adversarial multi-model critique and returns a signed verdict: ALLOW, BLOCK, or UNCERTAIN.
 
 ## Prerequisites
 
@@ -41,27 +41,60 @@ First call returns 402 with x402 payment details (amount, recipient, asset on Ba
 
 | Verdict | Meaning | Action |
 |---------|---------|--------|
-| `ALLOW` | Reasoning is sound | Execute the trade |
-| `HOLD` | Material defects found | Do not execute, review reasoning |
-| `UNCERTAIN` | Insufficient evidence | Gather more context |
-| `DISSENT` | Models strongly disagree | Require human review |
+| `ALLOW` | Reasoning passed verification | Proceed |
+| `BLOCK` | Material reasoning defects or unacceptable risk | Do not execute |
+| `UNCERTAIN` | Safe escalation state — insufficient clean evidence to justify ALLOW or BLOCK | Gather more context or require review |
 
-## Pricing (stake-proportional)
+## Pricing
 
-| Stake Level | Cost | Use case |
-|-------------|------|----------|
-| `low` | $0.008-$0.02 | Routine swaps under $2K |
-| `medium` | $0.02-$0.05 | Standard trades $2K-$10K |
-| `high` | $0.05-$0.15 | Large trades $10K-$25K |
-| `critical` | $0.15-$1.00 | High-value trades over $25K |
+ThoughtProof pricing is stake-based.
+
+| Stake Level | Standard | Lite | Use case |
+|-------------|----------|------|----------|
+| `low` | $0.01 | $0.005 | Routine low-value actions |
+| `medium` | $0.02 | $0.01 | Standard trades and service payments |
+| `high` | $0.05 | — | Large or sensitive actions |
+| `critical` | $0.10 | — | High-value or highly risky actions |
+
+Notes:
+- `lite` is only available for `low` and `medium` stake.
+- `high` and `critical` always execute on the standard tier.
+- Billing follows the executed tier, not the requested tier.
 
 ## Example workflow
 
-1. User says: "Swap $5K USDC for ETH"
-2. Check reasoning via curl to ThoughtProof API with the trade thesis
-3. If `HOLD` or `DISSENT` -- warn user, show objections, do not proceed
-4. If `ALLOW` with confidence > 0.60 -- execute the swap
+### MoonPay + ThoughtProof: payment layer + verification layer
+
+MoonPay handles the payment execution.
+ThoughtProof verifies whether the decision to pay is well-reasoned before settlement.
+
+Example:
+
+1. User says: "Swap $5K USDC for ETH because CT is bullish."
+2. Agent prepares the MoonPay swap request.
+3. Before calling `moonpay-swap-tokens`, the agent sends the reasoning to ThoughtProof.
+4. ThoughtProof returns:
+   - `ALLOW` → proceed with swap
+   - `BLOCK` → stop, surface objections
+   - `UNCERTAIN` → escalate, ask for clarification or review
+5. If verification passes, the MoonPay skill executes the swap.
+
+**Example failure:**
+- "Buy $50K of a token because influencers are bullish"
+- ThoughtProof → `BLOCK`
+- MoonPay execution never happens
+
+**Example pass:**
+- "Rebalance portfolio back to target allocation with defined slippage and stop-loss constraints"
+- ThoughtProof → `ALLOW`
+- MoonPay executes
+
+This gives the agent stack two layers:
+- **MoonPay** answers: *can* the transaction execute?
+- **ThoughtProof** answers: *should* the transaction execute?
 
 ## Related skills
 
-- **moonpay-swap-tokens** -- Execute the swap after verification passes
+- **moonpay-swap-tokens** — Execute the swap after verification passes
+
+  

--- a/skills/thoughtproof-reasoning-check/SKILL.md
+++ b/skills/thoughtproof-reasoning-check/SKILL.md
@@ -96,5 +96,3 @@ This gives the agent stack two layers:
 ## Related skills
 
 - **moonpay-swap-tokens** — Execute the swap after verification passes
-
-  


### PR DESCRIPTION
## What changed

Updates the `thoughtproof-reasoning-check` skill to align with the **pot-sdk v2.0 public API** (now live at api.thoughtproof.ai).

### Verdict enum
- Replaced `HOLD` / `DISSENT` with the v2.0 triadic interface: `ALLOW` / `BLOCK` / `UNCERTAIN`
- `UNCERTAIN` is now clearly framed as a **safe escalation state**, not model uncertainty
- The live API has been updated — v1 verdicts no longer appear in public responses

### Pricing
- Updated to stake-based `lite` / `standard` tier model
- `lite` is only available for `low` and `medium` stake
- `high` and `critical` always execute on standard tier
- Billing follows the executed tier, not the requested tier

### Example workflow
- Replaced generic workflow with a concrete **MoonPay + ThoughtProof** layered example
- MoonPay answers: *can* the transaction execute?
- ThoughtProof answers: *should* it execute?
- Failure case: "Buy $50K because influencers are bullish" → `BLOCK`
- Pass case: "Rebalance to target allocation with defined slippage" → `ALLOW`
