### PR TITLE
feat: add nansen-dca-tracker — smart money DCA tracking on Solana

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -136,6 +136,15 @@
         "./skills/alchemy-agentic-gateway",
         "./skills/alchemy-api"
       ]
+    },
+    {
+      "name": "nansen-skills",
+      "description": "Nansen on-chain analytics — smart money DCA tracking, wallet labels, token flow intelligence, and whale activity on Solana.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/nansen-dca-tracker"
+      ]
     }
   ]
 }

--- a/skills/nansen-dca-tracker/SKILL.md
+++ b/skills/nansen-dca-tracker/SKILL.md
@@ -20,12 +20,25 @@ allowed-tools: Bash(nansen:*)
 
 **Answers:** "What tokens are whales dollar-cost averaging into on Solana?"
 
+## Prerequisites
+
+- Nansen CLI installed: `npm i -g nansen-cli`
+- API key set: `export NANSEN_API_KEY=<your-key>` (get one at https://app.nansen.ai)
+
+## Workflow
+
+1. Fetch the latest smart money DCA strategies on Solana:
+
 ```bash
 nansen research smart-money dcas --limit 20
 # → trader_address, trader_address_label, input/output_token_symbol, deposit_value_usd, dca_status, dca_created_at
+```
 
-# For each top DCA target, check token fundamentals
+2. For each top DCA target, check token fundamentals:
+
+```bash
 TARGET=<output_token_address>
+
 nansen research token info --token $TARGET --chain solana
 # → name, symbol, price, market_cap, token_details
 
@@ -33,6 +46,12 @@ nansen research token flow-intelligence --token $TARGET --chain solana
 # → net_flow_usd per label: smart_trader, whale, exchange, fresh_wallets
 ```
 
-To see DCA strategies targeting a specific token: `nansen research token jup-dca --token $TARGET`
+3. To see all DCA strategies targeting a specific token:
 
-DCAs show long-term conviction — SM DCA targets with positive smart_trader_net_flow = high-confidence accumulation.
+```bash
+nansen research token jup-dca --token $TARGET
+```
+
+## Interpretation
+
+DCAs show long-term conviction — SM DCA targets with positive `smart_trader_net_flow` = high-confidence accumulation signal.

--- a/skills/nansen-dca-tracker/SKILL.md
+++ b/skills/nansen-dca-tracker/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: nansen-dca-tracker
+description: "What tokens are whales dollar-cost averaging into? Jupiter DCA strategies by smart money and target token fundamentals."
+metadata:
+  openclaw:
+    requires:
+      env:
+        - NANSEN_API_KEY
+      bins:
+        - nansen
+    primaryEnv: NANSEN_API_KEY
+    install:
+      - kind: node
+        package: nansen-cli
+        bins: [nansen]
+allowed-tools: Bash(nansen:*)
+---
+
+# DCA Watch
+
+**Answers:** "What tokens are whales dollar-cost averaging into on Solana?"
+
+```bash
+nansen research smart-money dcas --limit 20
+# → trader_address, trader_address_label, input/output_token_symbol, deposit_value_usd, dca_status, dca_created_at
+
+# For each top DCA target, check token fundamentals
+TARGET=<output_token_address>
+nansen research token info --token $TARGET --chain solana
+# → name, symbol, price, market_cap, token_details
+
+nansen research token flow-intelligence --token $TARGET --chain solana
+# → net_flow_usd per label: smart_trader, whale, exchange, fresh_wallets
+```
+
+To see DCA strategies targeting a specific token: `nansen research token jup-dca --token $TARGET`
+
+DCAs show long-term conviction — SM DCA targets with positive smart_trader_net_flow = high-confidence accumulation.

--- a/skills/nansen-dca-tracker/SKILL.md
+++ b/skills/nansen-dca-tracker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nansen-dca-tracker
 description: "What tokens are whales dollar-cost averaging into? Jupiter DCA strategies by smart money and target token fundamentals."
+tags: [nansen, smart-money, dca, solana, jupiter]
 metadata:
   openclaw:
     requires:
@@ -49,7 +50,7 @@ nansen research token flow-intelligence --token $TARGET --chain solana
 3. To see all DCA strategies targeting a specific token:
 
 ```bash
-nansen research token jup-dca --token $TARGET
+nansen research token jup-dca --token $TARGET --chain solana
 ```
 
 ## Interpretation


### PR DESCRIPTION
## Skill name
nansen-dca-tracker

## Description
Answers "what tokens are whales DCA-ing into on Solana?" — queries smart money Jupiter DCA strategies via the Nansen CLI, then pulls token fundamentals and flow intelligence for each target.

## Primary chain
Solana

## Primary token
SOL / SPL tokens

## Checklist
- [x] Frontmatter (name, description) present
- [x] Registered in .claude-plugin/marketplace.json under nansen-skills plugin
- [x] Naming convention: nansen-{name}/
- [x] Uses nansen-cli (npm: nansen-cli) — real package
- [x] No Python/TypeScript code — pure CLI commands
- [x] NANSEN_API_KEY env var documented

## MoonPay Integration
Fund a Solana wallet to act on DCA signals discovered via Nansen:
```bash
mp buy --token sol_solana --amount 0.5 --wallet <solana-address> --email <email>
```

## Example Usage
```bash
export NANSEN_API_KEY=your_key

# Find top smart money DCA targets
nansen research smart-money dcas --limit 20

# Check fundamentals + flow for the top target
nansen research token info --token <output_token_address> --chain solana
nansen research token flow-intelligence --token <output_token_address> --chain solana
```