### PR TITLE
docs: add zerion-wallet-data to Partner Skills README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See the [moonpay-mcp](skills/moonpay-mcp/SKILL.md) skill for setup details.
 |-------|-------------|
 | [corbits-marketplace](skills/corbits-marketplace/) | Paid API marketplace with x402 micropayments |
 | [myriad-prediction-markets](skills/myriad-prediction-markets/) | BNB Chain prediction market trading |
+| [zerion-wallet-data](skills/zerion-wallet-data/) | Interpreted on-chain wallet data via x402 — portfolios, DeFi positions, PnL, transactions, NFTs |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Adds `zerion-wallet-data` to the Partner Skills table in README.md
- Companion to #35 which adds the actual skill

## Checklist
- [x] Only README touched
- [x] Link and description match SKILL.md