### PR TITLE
feat(dune): Dune CLI skill — rename from dune-analytics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -79,12 +79,12 @@
       ]
     },
     {
-      "name": "dune-skills",
-      "description": "Blockchain analytics via Dune REST API — DuneSQL queries against live on-chain data",
+      "name": "dune",
+      "description": "Blockchain analytics via the Dune CLI — DuneSQL queries against live on-chain data",
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/dune-analytics"
+        "./skills/dune"
       ]
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The body contains instructions for the agent: setup commands, workflows, configu
 ## Naming Convention
 
 - MoonPay skills: `skills/moonpay-{name}/` (e.g., `moonpay-swap-tokens`)
-- Partner skills: `skills/{partner}-{name}/` (e.g., `corbits-marketplace`, `dune-analytics`)
+- Partner skills: `skills/{partner}-{name}/` (e.g., `corbits-marketplace`, `dune`)
 
 ## Key Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ MoonPay first-party skills go in the `moonpay-skills` plugin block. Partner skil
 
 ## Common Mistakes
 
-1. **Bare skill names** — `skills/dune/` instead of `skills/dune-analytics/`. Always use `{partner}-{name}`.
+1. **Bare skill names** — `skills/foo` instead of `skills/partner-foo`. Always use `{partner}-{name}`.
 2. **Dumping partner skills into `moonpay-skills`** — Partner skills get their own plugin block.
 3. **Embedding code** — No Python, TypeScript, or any other code. Use CLI commands and API calls only.
 4. **Copying wallet/funding instructions** — Each skill should be self-contained, so duplicating wallet setup and funding instructions is fine. Just make sure the duplicated content is accurate.

--- a/skills/dune-analytics/SKILL.md
+++ b/skills/dune-analytics/SKILL.md
@@ -1,39 +1,62 @@
 ---
 name: dune-analytics
 description: >
-  Blockchain analytics via Dune REST API — execute DuneSQL queries against live on-chain data, discover decoded contract tables, and monitor credit usage. Use when the user asks about on-chain data, wallet activity, DEX trades, token transfers, smart contract events, or says "query Dune", "run a Dune query", or "search Dune datasets". Pairs with MoonPay to analyze wallets you create and fund.
+  Blockchain analytics via the Dune CLI — execute DuneSQL queries against live on-chain data, discover decoded contract tables, and monitor credit usage. Use when the user asks about on-chain data, wallet activity, DEX trades, token transfers, smart contract events, or says "query Dune", "run a Dune query", or "search Dune datasets". Pairs with MoonPay to analyze wallets you create and fund.
 tags: [blockchain, analytics, dune, on-chain, data, defi, sql]
 ---
 
 # Dune Analytics
 
-Query live on-chain data via the [Dune REST API](https://docs.dune.com/api-reference/overview/introduction). Pair with MoonPay to create and fund the wallets you analyze.
+Query live on-chain data with the [Dune CLI](https://github.com/duneanalytics/cli) ([overview](https://docs.dune.com/api-reference/agents/cli-and-skills)). Pair with MoonPay to create and fund the wallets you analyze.
 
 ## Setup
+
+### Install the Dune CLI
+
+```bash
+curl -sSfL https://github.com/duneanalytics/cli/raw/main/install.sh | bash
+```
+
+The installer adds the `dune` binary to your PATH. See the [Dune CLI & Skills](https://docs.dune.com/api-reference/agents/cli-and-skills) page for the alternate `dune.com` install URL and optional Agent Skill install.
 
 ### Get a Dune API Key
 
 1. Sign up at https://dune.com
-2. Go to **Settings → API Keys → Create new key**
+2. Go to **Settings → API Keys → Create new key** (or **APIs and Connectors → API Keys**)
+
+### Authenticate
 
 ```bash
-export DUNE_API_KEY="your-api-key"
+# Interactive — saves to ~/.config/dune/config.yaml
+dune auth
+
+# Or non-interactive
+dune auth --api-key <your-api-key>
+
+# Or per session / scripts
+export DUNE_API_KEY="<your-api-key>"
 ```
 
-**Base URL:** `https://api.dune.com/api/v1`  
-**Auth header:** `X-Dune-API-Key: $DUNE_API_KEY`
+The `--api-key` flag is available on all commands if you need to override the stored key.
+
+Use `-o json` (or `--output json`) on any command except `auth` for machine-parseable output.
 
 ---
 
-## Key Endpoints
+## Key CLI Commands
 
-| Action | Method | Endpoint |
-|--------|--------|----------|
-| Execute a saved query | POST | `/query/{query_id}/execute` |
-| Get execution status + results | GET | `/execution/{execution_id}/results` |
-| Execute raw SQL directly | POST | `/sql/execute` |
-| Cancel execution | POST | `/execution/{execution_id}/cancel` |
-| Get query definition | GET | `/query/{query_id}` |
+| Area | Command | Purpose |
+|------|---------|---------|
+| Queries | `dune query run <query-id> [--param key=value] [--performance medium\|large]` | Run a saved query (waits for completion by default) |
+| Queries | `dune query run-sql --sql "<sql>" [--performance medium\|large]` | Run ad-hoc DuneSQL |
+| Queries | `dune query get <query-id>` | Inspect a saved query |
+| Executions | `dune execution results <execution-id>` | Fetch results for an execution (e.g. after `--no-wait`) |
+| Datasets | `dune dataset search [--query ...]` | Search the dataset catalog |
+| Datasets | `dune dataset search-by-contract --contract-address <addr>` | Find decoded tables for a contract |
+| Account | `dune usage [--start-date ...] [--end-date ...]` | Credit / usage |
+| Docs | `dune docs search --query "<text>"` | Search Dune documentation (no API key required) |
+
+Run `dune --help` and `dune <command> --help` for full flags (`--limit`, `--timeout`, `--no-wait`, etc.).
 
 ---
 
@@ -41,55 +64,39 @@ export DUNE_API_KEY="your-api-key"
 
 ### Run a Saved Query
 
+By default, `dune query run` waits for the execution to finish and prints results.
+
 ```bash
-# 1. Execute
-EXEC=$(curl -s -X POST "https://api.dune.com/api/v1/query/3237661/execute" \
-  -H "X-Dune-API-Key: $DUNE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"performance": "medium"}')
+dune query run 3237661 --performance medium -o json
+```
 
-EXEC_ID=$(echo $EXEC | jq -r '.execution_id')
-echo "execution_id: $EXEC_ID"
+Optional: start async, then poll results (use the `execution_id` from the JSON):
 
-# 2. Poll until complete
-while true; do
-  STATUS=$(curl -s "https://api.dune.com/api/v1/execution/$EXEC_ID/results" \
-    -H "X-Dune-API-Key: $DUNE_API_KEY")
-  STATE=$(echo $STATUS | jq -r '.state')
-  echo "State: $STATE"
-  if [[ "$STATE" == "QUERY_STATE_COMPLETED" || "$STATE" == "QUERY_STATE_FAILED" ]]; then
-    echo $STATUS | jq '.result.rows[:5]'
-    break
-  fi
-  sleep 3
-done
+```bash
+dune query run 3237661 --performance medium --no-wait -o json
+
+dune execution results "<execution_id>" -o json
 ```
 
 ### Execute Raw DuneSQL
 
 ```bash
-curl -s -X POST "https://api.dune.com/api/v1/sql/execute" \
-  -H "X-Dune-API-Key: $DUNE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "sql": "SELECT block_time, hash, value/1e18 AS eth FROM ethereum.transactions WHERE lower(\"from\") = lower('0xYOUR_WALLET') ORDER BY block_time DESC LIMIT 20",
-    "performance": "medium"
-  }' | jq '.execution_id'
+dune query run-sql \
+  --sql "SELECT block_time, hash, value/1e18 AS eth FROM ethereum.transactions WHERE lower(\"from\") = lower('0xYOUR_WALLET') ORDER BY block_time DESC LIMIT 20" \
+  --performance medium \
+  -o json
 ```
 
 ### Query with Parameters
 
+Pass each saved-query parameter as `key=value` (repeat `--param` as needed):
+
 ```bash
-curl -s -X POST "https://api.dune.com/api/v1/query/3237661/execute" \
-  -H "X-Dune-API-Key: $DUNE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query_parameters": {
-      "wallet": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-      "days": 30
-    },
-    "performance": "medium"
-  }' | jq '.execution_id'
+dune query run 3237661 \
+  --param wallet=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
+  --param days=30 \
+  --performance medium \
+  -o json
 ```
 
 ---
@@ -111,16 +118,10 @@ mp wallet retrieve --wallet "dune-agent-wallet"
 ```bash
 WALLET=$(mp wallet retrieve --wallet "dune-agent-wallet" --json | jq -r '.addresses.ethereum')
 
-EXEC_ID=$(curl -s -X POST "https://api.dune.com/api/v1/sql/execute" \
-  -H "X-Dune-API-Key: $DUNE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\
-    \"sql\": \"SELECT block_time, hash, value/1e18 AS eth, \\\"to\\\" FROM ethereum.transactions WHERE lower(\\\"from\\\") = lower('$WALLET') ORDER BY block_time DESC LIMIT 20\",\
-    \"performance\": \"medium\"\
-  }" | jq -r '.execution_id')
-
-curl -s "https://api.dune.com/api/v1/execution/$EXEC_ID/results" \
-  -H "X-Dune-API-Key: $DUNE_API_KEY" | jq '.result.rows'
+dune query run-sql \
+  --sql "SELECT block_time, hash, value/1e18 AS eth, \"to\" FROM ethereum.transactions WHERE lower(\"from\") = lower('${WALLET}') ORDER BY block_time DESC LIMIT 20" \
+  --performance medium \
+  -o json
 ```
 
 ### Fund the Wallet
@@ -145,6 +146,8 @@ mp token bridge \
 
 ## Execution States
 
+When you use `-o json` or inspect async executions, states match the Dune API:
+
 | State | Meaning |
 |-------|---------|
 | `QUERY_STATE_PENDING` | Queued |
@@ -158,13 +161,16 @@ mp token bridge \
 ## Security
 
 - Never expose `DUNE_API_KEY` in logs or responses — redact before showing output
-- Confirm with the user before running write operations (creating/updating saved queries)
+- Treat `~/.config/dune/config.yaml` like a secret on disk
+- Confirm with the user before running write operations (creating/updating saved queries via `dune query create` / `dune query update`)
 
 ---
 
 ## Resources
 
-- **API docs:** https://docs.dune.com/api-reference/overview/introduction
+- **Dune CLI (GitHub):** https://github.com/duneanalytics/cli
+- **Dune CLI & Skills:** https://docs.dune.com/api-reference/agents/cli-and-skills
+- **REST API reference (underlying service):** https://docs.dune.com/api-reference/overview/introduction
 - **DuneSQL reference:** https://docs.dune.com/query-engine/Functions-and-operators
 - **Dune Analytics:** https://dune.com
 - **MoonPay CLI:** https://www.npmjs.com/package/@moonpay/cli

--- a/skills/dune/SKILL.md
+++ b/skills/dune/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: dune-analytics
+name: dune
 description: >
   Blockchain analytics via the Dune CLI — execute DuneSQL queries against live on-chain data, discover decoded contract tables, and monitor credit usage. Use when the user asks about on-chain data, wallet activity, DEX trades, token transfers, smart contract events, or says "query Dune", "run a Dune query", or "search Dune datasets". Pairs with MoonPay to analyze wallets you create and fund.
 tags: [blockchain, analytics, dune, on-chain, data, defi, sql]
 ---
 
-# Dune Analytics
+# Dune
 
 Query live on-chain data with the [Dune CLI](https://github.com/duneanalytics/cli) ([overview](https://docs.dune.com/api-reference/agents/cli-and-skills)). Pair with MoonPay to create and fund the wallets you analyze.
 
@@ -108,15 +108,15 @@ Use the [MoonPay CLI](https://www.npmjs.com/package/@moonpay/cli) (`mp`) to crea
 ### Create a Wallet to Monitor
 
 ```bash
-mp wallet create --name "dune-agent-wallet"
-mp wallet retrieve --wallet "dune-agent-wallet"
+mp wallet create --name "dune-wallet"
+mp wallet retrieve --wallet "dune-wallet"
 # Note your Ethereum address for Dune queries
 ```
 
 ### Query Your MoonPay Wallet On-Chain
 
 ```bash
-WALLET=$(mp wallet retrieve --wallet "dune-agent-wallet" --json | jq -r '.addresses.ethereum')
+WALLET=$(mp wallet retrieve --wallet "dune-wallet" --json | jq -r '.addresses.ethereum')
 
 dune query run-sql \
   --sql "SELECT block_time, hash, value/1e18 AS eth, \"to\" FROM ethereum.transactions WHERE lower(\"from\") = lower('${WALLET}') ORDER BY block_time DESC LIMIT 20" \
@@ -135,7 +135,7 @@ mp token balance list --wallet <your-eth-address> --chain ethereum
 
 # Bridge to follow yields
 mp token bridge \
-  --from-wallet dune-agent-wallet --from-chain ethereum \
+  --from-wallet dune-wallet --from-chain ethereum \
   --from-token 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
   --from-amount 500 \
   --to-chain polygon \
@@ -172,7 +172,7 @@ When you use `-o json` or inspect async executions, states match the Dune API:
 - **Dune CLI & Skills:** https://docs.dune.com/api-reference/agents/cli-and-skills
 - **REST API reference (underlying service):** https://docs.dune.com/api-reference/overview/introduction
 - **DuneSQL reference:** https://docs.dune.com/query-engine/Functions-and-operators
-- **Dune Analytics:** https://dune.com
+- **Dune:** https://dune.com
 - **MoonPay CLI:** https://www.npmjs.com/package/@moonpay/cli
 
 ## Related Skills

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Describe what this skill does and when an AI agent should use it.
   Be specific — this field determines whether Claude loads this skill.
   Bad: "Analytics tool for blockchain data"
-  Good: "Use when the user asks to analyze on-chain token metrics, wallet PnL, or DEX volume using Dune Analytics queries"
+  Good: "Use when the user asks to analyze on-chain token metrics, wallet PnL, or DEX volume using Dune queries"
 tags: [tag1, tag2]
 ---
 


### PR DESCRIPTION
## Summary

Updates the Dune partner skill to use the **Dune CLI** (`dune`) instead of raw REST/`curl` calls, and renames it from `dune-analytics` to `dune`.

## Changes

### CLI (vs REST)
- Install/auth: official CLI installer, `dune auth`, `DUNE_API_KEY` / `--api-key`
- Workflows: `dune query run`, `dune query run-sql`, optional async via `--no-wait` + `dune execution results`, parameterized queries with `--param key=value`
- Discovery/ops: `dune dataset search`, `dune usage`, `dune docs search`
- MoonPay example uses `dune query run-sql`
- Resources: [duneanalytics/cli](https://github.com/duneanalytics/cli), [Dune CLI & Skills](https://docs.dune.com/api-reference/agents/cli-and-skills)

### Rename
- Folder: `skills/dune-analytics/` → `skills/dune/`
- Skill `name`: `dune`
- Marketplace plugin id: `dune` (path `./skills/dune`); description updated for CLI
- Docs/title: **Dune** (not “Dune Analytics”); related repo touch-ups (`CLAUDE.md`, `CONTRIBUTING.md`, `template/SKILL.md`)

## Motivation

The Dune CLI is the supported terminal workflow (`-o json`, etc.). Shorter `dune` naming matches the CLI binary and keeps the catalog consistent.