### PR TITLE
feat: add wallet status line skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,6 +35,8 @@
         "./skills/moonpay-trading-automation",
         "./skills/moonpay-upgrade",
         "./skills/moonpay-virtual-account",
+        "./skills/moonpay-wallet-statusline-refresh",
+        "./skills/moonpay-wallet-statusline",
         "./skills/moonpay-x402"
       ]
     },

--- a/skills/moonpay-wallet-statusline-refresh/SKILL.md
+++ b/skills/moonpay-wallet-statusline-refresh/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: moonpay-wallet-statusline-refresh
 description: >
-  Manually refresh wallet balances shown in the terminal status line. Use when
-  the user says "refresh balances", "update status bar", or after receiving
-  funds from outside the CLI.
+  Manually refresh wallet balances shown in the Claude Code status line. Use
+  when the user says "refresh balances", "update status bar", or after
+  receiving funds from outside the CLI.
 tags: [wallet, statusline]
 ---
 
@@ -11,13 +11,16 @@ tags: [wallet, statusline]
 
 ## Goal
 
-Refresh the cached wallet balances displayed in the terminal status line.
+Refresh the cached MoonPay wallet balances shown in the Claude Code status line.
 
 ## Prerequisites
 
 - MoonPay CLI installed: `npm i -g @moonpay/cli`
-- Authenticated: `mp user retrieve`
-- Status line configured: `~/.config/moonpay/statusline.json` exists (run `moonpay-wallet-statusline` to set up)
+- Authenticated: `mp verify`
+- Status line config exists: `~/.config/moonpay/statusline.json`
+- Refresh script exists: `~/.config/moonpay/refresh-statusline.sh`
+
+If the config or refresh script is missing, run the `moonpay-wallet-statusline` setup skill first.
 
 ## Commands
 
@@ -25,38 +28,48 @@ Refresh the cached wallet balances displayed in the terminal status line.
 # Run the refresh script
 bash ~/.config/moonpay/refresh-statusline.sh
 
-# View the cached output
+# View cached output
 cat ~/.config/moonpay/statusline-cache.txt
 
-# View balances directly (for reporting to user)
-mp bitcoin balance retrieve --wallet <btc-address>
-mp token balance list --wallet <address> --chain <chain>
+# Strip ANSI codes for plain text output
+sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
+
+# Check authentication if refresh fails
+mp verify
 ```
 
 ## Workflow
 
-1. **Check config exists** — verify `~/.config/moonpay/statusline.json` exists. If not, tell the user to run the `moonpay-wallet-statusline` setup skill first.
+1. Verify the setup files exist:
+   - `~/.config/moonpay/statusline.json`
+   - `~/.config/moonpay/refresh-statusline.sh`
 
-2. **Check refresh script exists** — verify `~/.config/moonpay/refresh-statusline.sh` exists. If not, tell the user to run the `moonpay-wallet-statusline` setup skill first.
+2. Run the refresh command:
 
-3. **Run refresh**:
    ```bash
    bash ~/.config/moonpay/refresh-statusline.sh
    ```
 
-4. **Report balances** — read the config to find which wallets/chains are tracked, then run the underlying `mp` commands to show the user their current balances in a readable format:
-   - For bitcoin: `mp bitcoin balance retrieve --wallet <addr>`
-   - For other chains: `mp token balance list --wallet <addr> --chain <chain>`
+3. If the cache file exists, show the user the refreshed value in plain text:
 
-5. **Confirm** — tell the user the status line cache has been updated.
+   ```bash
+   sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
+   ```
+
+4. If the cache file does not exist after a successful refresh, tell the user no balances were found for the configured address-and-chain entries.
+
+5. Only query the underlying `mp` balance commands directly if the user explicitly asks for a detailed balance breakdown. Otherwise, trust the configured refresh script as the source of truth for the status line.
+
+6. Confirm that the cache was refreshed and remind the user that Claude Code may show the change on the next status line render or next session, depending on local setup.
 
 ## Error handling
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| No config file | Setup not run | Run `moonpay-wallet-statusline` skill |
-| No refresh script | Setup not run | Run `moonpay-wallet-statusline` skill |
-| `mp` fetch failed | Auth expired or network issue | Run `mp user retrieve` to check, then `mp login` if needed |
+| No config file | Setup not run | Run `moonpay-wallet-statusline` first |
+| No refresh script | Setup not run | Run `moonpay-wallet-statusline` first |
+| `mp verify` failed | Auth expired or missing | Run `mp login` then `mp verify` |
+| Refresh exits successfully but cache is missing | No balances on configured entries | Check the configured addresses/chains and verify the wallet has funds |
 
 ## Related skills
 

--- a/skills/moonpay-wallet-statusline-refresh/SKILL.md
+++ b/skills/moonpay-wallet-statusline-refresh/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: moonpay-wallet-statusline-refresh
 description: >
-  Manually refresh wallet balances shown in the Claude Code status line. Use
+  Manually refresh wallet balances shown in a compatible CLI status line. Use
   when the user says "refresh balances", "update status bar", or after
   receiving funds from outside the CLI.
 tags: [wallet, statusline]
@@ -11,7 +11,7 @@ tags: [wallet, statusline]
 
 ## Goal
 
-Refresh the cached MoonPay wallet balances shown in the Claude Code status line.
+Refresh the cached MoonPay wallet balances shown in a compatible CLI status line.
 
 ## Prerequisites
 
@@ -60,7 +60,7 @@ mp verify
 
 5. Only query the underlying `mp` balance commands directly if the user explicitly asks for a detailed balance breakdown. Otherwise, trust the configured refresh script as the source of truth for the status line.
 
-6. Confirm that the cache was refreshed and remind the user that Claude Code may show the change on the next status line render or next session, depending on local setup.
+6. Confirm that the cache was refreshed and remind the user that the target CLI may show the change on the next status line render or next session, depending on local setup.
 
 ## Error handling
 

--- a/skills/moonpay-wallet-statusline-refresh/SKILL.md
+++ b/skills/moonpay-wallet-statusline-refresh/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: moonpay-wallet-statusline-refresh
+description: >
+  Manually refresh wallet balances shown in the terminal status line. Use when
+  the user says "refresh balances", "update status bar", or after receiving
+  funds from outside the CLI.
+tags: [wallet, statusline]
+---
+
+# Refresh wallet status line
+
+## Goal
+
+Refresh the cached wallet balances displayed in the terminal status line.
+
+## Prerequisites
+
+- MoonPay CLI installed: `npm i -g @moonpay/cli`
+- Authenticated: `mp user retrieve`
+- Status line configured: `~/.config/moonpay/statusline.json` exists (run `moonpay-wallet-statusline` to set up)
+
+## Commands
+
+```bash
+# Run the refresh script
+bash ~/.config/moonpay/refresh-statusline.sh
+
+# View the cached output
+cat ~/.config/moonpay/statusline-cache.txt
+
+# View balances directly (for reporting to user)
+mp bitcoin balance retrieve --wallet <btc-address>
+mp token balance list --wallet <address> --chain <chain>
+```
+
+## Workflow
+
+1. **Check config exists** — verify `~/.config/moonpay/statusline.json` exists. If not, tell the user to run the `moonpay-wallet-statusline` setup skill first.
+
+2. **Check refresh script exists** — verify `~/.config/moonpay/refresh-statusline.sh` exists. If not, tell the user to run the `moonpay-wallet-statusline` setup skill first.
+
+3. **Run refresh**:
+   ```bash
+   bash ~/.config/moonpay/refresh-statusline.sh
+   ```
+
+4. **Report balances** — read the config to find which wallets/chains are tracked, then run the underlying `mp` commands to show the user their current balances in a readable format:
+   - For bitcoin: `mp bitcoin balance retrieve --wallet <addr>`
+   - For other chains: `mp token balance list --wallet <addr> --chain <chain>`
+
+5. **Confirm** — tell the user the status line cache has been updated.
+
+## Error handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| No config file | Setup not run | Run `moonpay-wallet-statusline` skill |
+| No refresh script | Setup not run | Run `moonpay-wallet-statusline` skill |
+| `mp` fetch failed | Auth expired or network issue | Run `mp user retrieve` to check, then `mp login` if needed |
+
+## Related skills
+
+- [moonpay-wallet-statusline](../moonpay-wallet-statusline/) — Initial setup for wallet status line
+- [moonpay-check-wallet](../moonpay-check-wallet/) — Detailed portfolio breakdown with allocation percentages

--- a/skills/moonpay-wallet-statusline/SKILL.md
+++ b/skills/moonpay-wallet-statusline/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: moonpay-wallet-statusline
 description: >
-  Add wallet balances to the terminal status line. Use when the user asks to
-  "show balances in the status bar", "add wallet to status line", or wants a
-  persistent balance display while working.
+  Show MoonPay wallet balances in the Claude Code status line using a local
+  cache and refresh script. Use when the user asks to "show balances in the
+  status bar", "add wallet to Claude status line", or wants a persistent
+  balance display while working.
 tags: [wallet, statusline]
 ---
 
@@ -11,7 +12,13 @@ tags: [wallet, statusline]
 
 ## Goal
 
-Display cached wallet balances in a terminal status line. Creates a config file, a refresh script, and a pre-rendered cache file that any status line can read.
+Display cached MoonPay wallet balances in the Claude Code status line. This skill creates:
+
+- `~/.config/moonpay/statusline.json` — tracked wallets, chains, and format
+- `~/.config/moonpay/refresh-statusline.sh` — refreshes balances from the MoonPay CLI
+- `~/.config/moonpay/statusline-cache.txt` — pre-rendered ANSI output for the status line
+
+Any other status display can also read the cache file directly.
 
 ## Prerequisites
 
@@ -19,71 +26,117 @@ Display cached wallet balances in a terminal status line. Creates a config file,
 - Authenticated: `mp login` then `mp verify`
 - At least one wallet: `mp wallet list`
 - `jq` installed: `which jq`
-- `bc` installed (for USD totals): `which bc`
+- `bc` installed: `which bc`
+- For Claude Code: the built-in status line setup has already been run, so `~/.claude/settings.json` has a `statusLine` config and `~/.claude/statusline.sh` exists
 
 ## Commands
 
 ```bash
 # List wallets
 mp wallet list
+mp --json wallet list
 
 # Fetch balances (used by the refresh script)
-mp --json wallet list
 mp --json bitcoin balance retrieve --wallet <btc-address>
 mp --json token balance list --wallet <address> --chain <chain>
+
+# Refresh the status line cache
+bash ~/.config/moonpay/refresh-statusline.sh
 ```
 
 ## Supported chains
 
 `solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `optimism`, `bnb`, `avalanche`, `tron`, `bitcoin`, `ton`, `filecoin`
 
-Bitcoin uses a separate command (`mp bitcoin balance retrieve`) and does not return USD values.
+Bitcoin uses a separate command (`mp bitcoin balance retrieve`) and does not return USD values, so it is excluded from USD totals.
 
 ## Workflow
 
-### 1. Select wallets
+### 1. Verify prerequisites
 
-Run `mp wallet list` and ask the user which wallet(s) to track. For each wallet, ask which chains to display. Skip testnets/devnets by default (filter out chains containing "testnet", "devnet", "sepolia", "amoy", "tempo").
+Run:
 
-### 2. Select display format
+```bash
+mp verify
+mp wallet list
+which jq
+which bc
+```
 
-- `amount` — symbol + balance (e.g., `BTC 0.00071`)
-- `amount+usd` — symbol + balance + USD (e.g., `mpSOL 0.00092 ($0.08)`). Bitcoin always shows amount only (no USD from the API).
-- `total+breakdown` — total USD + per-token (e.g., `$0.08 — mpSOL 0.00092`). Bitcoin balance is excluded from the USD total.
+If the user wants Claude Code integration, also verify:
 
-### 3. Write config
+```bash
+test -f ~/.claude/statusline.sh && echo "statusline script present"
+```
 
-Save to `~/.config/moonpay/statusline.json`:
+If `~/.claude/statusline.sh` is missing or Claude Code is not configured with a `statusLine`, tell the user to run the built-in `/statusline` command first, or configure `statusLine` manually in `~/.claude/settings.json`, then come back to this skill.
+
+### 2. Select wallet addresses and chains
+
+Run `mp wallet list` and ask the user which wallet address(es) to track. Create one config entry per address and per chain.
+
+Skip testnets/devnets by default. Exclude chains containing:
+
+- `testnet`
+- `devnet`
+- `sepolia`
+- `amoy`
+- `tempo`
+
+### 3. Select display format
+
+- `amount` — symbol + balance (example: `BTC 0.00071`)
+- `amount+usd` — symbol + balance + USD when available (example: `mpSOL 0.00092 ($0.08)`)
+- `total+breakdown` — total USD first, then token breakdown (example: `$12.48 | SOL 0.03 ($4.55) | USDC 7.93 ($7.93)`)
+
+If the same symbol appears on multiple chains, keep separate entries rather than merging them.
+
+### 4. Write config
+
+Create the config directory if needed:
+
+```bash
+mkdir -p ~/.config/moonpay
+```
+
+Write `~/.config/moonpay/statusline.json`. Each entry must represent exactly one wallet address on exactly one chain. Prefer storing the resolved address directly instead of a wallet name.
 
 ```json
 {
-  "wallets": [
+  "entries": [
     {
-      "name": "btc-wallet",
-      "chains": ["bitcoin", "solana"]
+      "label": "btc-wallet",
+      "address": "bc1qexample...",
+      "chain": "bitcoin"
+    },
+    {
+      "label": "base-wallet",
+      "address": "0x1234...abcd",
+      "chain": "base"
+    },
+    {
+      "label": "sol-wallet",
+      "address": "So1anaExamplePubkey...",
+      "chain": "solana"
     }
   ],
-  "format": "amount"
+  "format": "amount+usd"
 }
 ```
 
-### 4. Create refresh script
+### 5. Create refresh script
 
-Write `~/.config/moonpay/refresh-statusline.sh` and make it executable (`chmod +x`). The script:
+Write `~/.config/moonpay/refresh-statusline.sh`, then make it executable with `chmod +x ~/.config/moonpay/refresh-statusline.sh`.
 
-1. Reads `~/.config/moonpay/statusline.json` for wallet names, chains, and format.
-2. Resolves wallet names to addresses via `mp --json wallet list`.
-3. Fetches balances per wallet+chain:
-   - Bitcoin: `mp --json bitcoin balance retrieve --wallet <addr>` — extracts `.total.btc`.
-   - Other chains: `mp --json token balance list --wallet <addr> --chain <chain>` — extracts `.items[].symbol`, `.items[].balance.amount`, `.items[].balance.value`.
-4. Formats output with ANSI colors:
-   - Token symbols in bold cyan (`\033[1;36m`), amounts in white (`\033[0;37m`), USD values in dim green (`\033[2;32m`).
-   - Tokens separated by dim ` | `.
-   - USD values rounded to 2 decimal places.
-   - Bitcoin uses the `₿` symbol; other tokens use the API-returned symbol.
-5. Writes the pre-rendered ANSI string to `~/.config/moonpay/statusline-cache.txt` using atomic write (temp file + `mv`).
-6. On error: keeps existing cache intact — never overwrites with empty or error output.
-7. If no balances found: removes the cache file.
+This script:
+
+1. Reads `~/.config/moonpay/statusline.json`
+2. Validates that each config entry has one `address` and one `chain`
+3. Fetches balances per configured address and chain
+4. Aborts on any configured fetch error, preserving the previous cache
+5. Formats ANSI-colored output for the status line
+6. Writes the cache atomically
+7. Deletes the cache if no balances are found
 
 ```bash
 #!/usr/bin/env bash
@@ -91,76 +144,254 @@ set -euo pipefail
 
 CONFIG="$HOME/.config/moonpay/statusline.json"
 CACHE="$HOME/.config/moonpay/statusline-cache.txt"
+TMP_CACHE="$(mktemp "${CACHE}.tmp.XXXXXX")"
 
-if [[ ! -f "$CONFIG" ]]; then exit 1; fi
+BOLD_CYAN=$'\033[1;36m'
+WHITE=$'\033[0;37m'
+DIM_GREEN=$'\033[2;32m'
+DIM=$'\033[2m'
+RESET=$'\033[0m'
 
-FORMAT=$(jq -r '.format // "amount"' "$CONFIG")
-# ... resolve wallets, fetch balances, format output, write cache
-# See moonpay-wallet-statusline-refresh skill for the refresh command
+cleanup() {
+  rm -f "$TMP_CACHE"
+}
+trap cleanup EXIT
+
+require_bin() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing dependency: $1" >&2
+    exit 1
+  }
+}
+
+trim_number() {
+  printf "%s" "$1" | sed -E 's/(\.[0-9]*[1-9])0+$/\1/; s/\.0+$//'
+}
+
+format_usd() {
+  printf '$%.2f' "${1:-0}"
+}
+
+join_by() {
+  local separator="$1"
+  shift
+  local first=1
+  for item in "$@"; do
+    if [[ $first -eq 1 ]]; then
+      printf "%s" "$item"
+      first=0
+    else
+      printf "%s%s" "$separator" "$item"
+    fi
+  done
+}
+
+require_bin mp
+require_bin jq
+require_bin bc
+
+[[ -f "$CONFIG" ]] || exit 1
+
+FORMAT="$(jq -r '.format // "amount"' "$CONFIG")"
+ENTRY_COUNT="$(jq '.entries | length' "$CONFIG")"
+[[ "$ENTRY_COUNT" -gt 0 ]] || {
+  rm -f "$CACHE"
+  exit 0
+}
+
+declare -a RENDERED=()
+USD_TOTAL="0"
+HAS_USD_TOTAL=0
+
+while IFS= read -r entry; do
+  entry_label="$(jq -r '.label // empty' <<<"$entry")"
+  wallet_address="$(jq -r '.address // empty' <<<"$entry")"
+  chain="$(jq -r '.chain // empty' <<<"$entry")"
+
+  [[ -n "$wallet_address" && -n "$chain" ]] || {
+    echo "invalid config entry: each item needs address and chain" >&2
+    exit 1
+  }
+
+  if [[ "$chain" == "bitcoin" ]]; then
+    if ! btc_json="$(mp --json bitcoin balance retrieve --wallet "$wallet_address" 2>/dev/null)"; then
+      echo "failed to fetch bitcoin balance for ${entry_label:-$wallet_address}" >&2
+      exit 1
+    fi
+
+    btc_amount="$(jq -r '.total.btc // empty' <<<"$btc_json")"
+    [[ -n "$btc_amount" && "$btc_amount" != "0" ]] || continue
+
+    amount_display="$(trim_number "$btc_amount")"
+    RENDERED+=("${BOLD_CYAN}₿@bitcoin${RESET} ${WHITE}${amount_display}${RESET}")
+    continue
+  fi
+
+  if ! token_json="$(mp --json token balance list --wallet "$wallet_address" --chain "$chain" 2>/dev/null)"; then
+    echo "failed to fetch token balances for ${entry_label:-$wallet_address} on ${chain}" >&2
+    exit 1
+  fi
+
+  while IFS= read -r token_entry; do
+    symbol="$(jq -r '.symbol // empty' <<<"$token_entry")"
+    amount="$(jq -r '.balance.amount // empty' <<<"$token_entry")"
+    usd_value="$(jq -r '.balance.value // empty' <<<"$token_entry")"
+
+    [[ -n "$symbol" && -n "$amount" ]] || continue
+    amount_display="$(trim_number "$amount")"
+    token_label="${symbol}@${chain}"
+
+    if [[ -n "$usd_value" && "$usd_value" != "null" ]]; then
+      USD_TOTAL="$(echo "$USD_TOTAL + $usd_value" | bc -l)"
+      HAS_USD_TOTAL=1
+    fi
+
+    case "$FORMAT" in
+      amount)
+        RENDERED+=("${BOLD_CYAN}${token_label}${RESET} ${WHITE}${amount_display}${RESET}")
+        ;;
+      amount+usd)
+        if [[ -n "$usd_value" && "$usd_value" != "null" ]]; then
+          RENDERED+=("${BOLD_CYAN}${token_label}${RESET} ${WHITE}${amount_display}${RESET} ${DIM_GREEN}($(format_usd "$usd_value"))${RESET}")
+        else
+          RENDERED+=("${BOLD_CYAN}${token_label}${RESET} ${WHITE}${amount_display}${RESET}")
+        fi
+        ;;
+      total+breakdown)
+        if [[ -n "$usd_value" && "$usd_value" != "null" ]]; then
+          RENDERED+=("${BOLD_CYAN}${token_label}${RESET} ${WHITE}${amount_display}${RESET} ${DIM_GREEN}($(format_usd "$usd_value"))${RESET}")
+        else
+          RENDERED+=("${BOLD_CYAN}${token_label}${RESET} ${WHITE}${amount_display}${RESET}")
+        fi
+        ;;
+      *)
+        RENDERED+=("${BOLD_CYAN}${token_label}${RESET} ${WHITE}${amount_display}${RESET}")
+        ;;
+    esac
+  done < <(
+    jq -c '
+      (.items // . // [])[]
+      | select(((.balance.amount // "0") | tonumber? // 0) > 0)
+    ' <<<"$token_json"
+  )
+done < <(jq -c '.entries[]' "$CONFIG")
+
+if [[ ${#RENDERED[@]} -eq 0 ]]; then
+  rm -f "$CACHE"
+  exit 0
+fi
+
+SEPARATOR="${DIM} | ${RESET}"
+TOKENS_LINE="$(join_by "$SEPARATOR" "${RENDERED[@]}")"
+
+if [[ "$FORMAT" == "total+breakdown" && "$HAS_USD_TOTAL" -eq 1 ]]; then
+  printf "%s%s%s" "${DIM_GREEN}$(format_usd "$USD_TOTAL")${RESET}" "$SEPARATOR" "$TOKENS_LINE" >"$TMP_CACHE"
+else
+  printf "%s" "$TOKENS_LINE" >"$TMP_CACHE"
+fi
+
+mv "$TMP_CACHE" "$CACHE"
 ```
 
-### 5. Run initial refresh
+### 6. Run initial refresh
 
 ```bash
 bash ~/.config/moonpay/refresh-statusline.sh
 ```
 
-Verify the cache file was created:
+Verify the cache file:
 
 ```bash
 cat ~/.config/moonpay/statusline-cache.txt
 ```
 
-### 6. Confirm
-
-Tell the user:
-- The cache file is at `~/.config/moonpay/statusline-cache.txt`
-- Run `moonpay-wallet-statusline-refresh` to manually update balances
-- The agent-specific integration section below explains how to wire it into a status display
-
-## Agent-specific integration
-
-### Claude Code
-
-Add this block to `~/.claude/statusline-command.sh` (before the render section):
+For plain text:
 
 ```bash
-# ── Wallet balances ──────────────────────────────────────────────────────────
-wallet_str=""
-wallet_cache="$HOME/.config/moonpay/statusline-cache.txt"
-if [ -f "$wallet_cache" ]; then
-  wallet_str=$(cat "$wallet_cache")
+sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
+```
+
+### 7. Wire into Claude Code
+
+Add this block to `~/.claude/statusline.sh` before the final render/output section. Match the surrounding script style if variable names differ.
+
+```bash
+# Wallet balances
+WALLET_CACHE="$HOME/.config/moonpay/statusline-cache.txt"
+WALLET_STR=""
+if [ -f "$WALLET_CACHE" ]; then
+  WALLET_STR="$(cat "$WALLET_CACHE")"
 fi
 
-if [ -n "$wallet_str" ]; then
-  [ -n "$line3" ] && line3="${line3}${SEP}"
-  line3="${line3}${wallet_str}"
+if [ -n "$WALLET_STR" ]; then
+  [ -n "$LINE3" ] && LINE3="${LINE3}${SEP}"
+  LINE3="${LINE3}${WALLET_STR}"
 fi
 ```
 
-Optionally add a PostToolUse hook to `~/.claude/settings.json` to auto-refresh after fund-moving commands:
+Optional on Claude Code v2.1.85+: add a `PostToolUse` hook to `~/.claude/settings.json` so balance-moving MoonPay commands refresh the cache automatically.
 
 ```json
 {
-  "matcher": "Bash",
-  "hooks": [{
-    "type": "command",
-    "if": "Bash(mp token swap:*)|Bash(mp token send:*)|Bash(mp token bridge:*)|Bash(mp bitcoin send:*)|Bash(mp buy:*)",
-    "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
-    "async": true
-  }]
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(mp token swap:*)",
+            "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
+            "async": true
+          },
+          {
+            "type": "command",
+            "if": "Bash(mp token send:*)",
+            "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
+            "async": true
+          },
+          {
+            "type": "command",
+            "if": "Bash(mp token bridge:*)",
+            "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
+            "async": true
+          },
+          {
+            "type": "command",
+            "if": "Bash(mp bitcoin send:*)",
+            "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
+            "async": true
+          },
+          {
+            "type": "command",
+            "if": "Bash(mp buy:*)",
+            "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 
-### Other agents
+### 8. Confirm
 
-Any agent with a terminal status display can read the cache file:
+Tell the user:
+
+- The cache file is `~/.config/moonpay/statusline-cache.txt`
+- Run `moonpay-wallet-statusline-refresh` to refresh manually
+- Changes appear in Claude Code on the next status line render or next session, depending on local setup
+
+## Other agents
+
+Any agent with a terminal status display can read the cache file directly:
 
 ```bash
 cat ~/.config/moonpay/statusline-cache.txt
 ```
 
-The cache contains a pre-rendered ANSI string. For plain text (no colors), strip ANSI codes:
+If the target status display does not support ANSI colors, strip ANSI codes first:
 
 ```bash
 sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
@@ -170,10 +401,12 @@ sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `mp: command not found` | CLI not installed | `npm i -g @moonpay/cli` |
+| `mp: command not found` | MoonPay CLI not installed | `npm i -g @moonpay/cli` |
 | `jq: command not found` | jq not installed | Install via package manager |
-| `failed to list wallets` | Not authenticated | Run `mp login` then `mp verify` |
-| Empty cache after refresh | No balances on configured chains | Check config chains, verify wallet has funds |
+| `bc: command not found` | bc not installed | Install via package manager |
+| `mp verify` failed | Not authenticated or expired auth | Run `mp login` then `mp verify` |
+| Empty cache after refresh | No balances found on configured entries | Check configured addresses/chains and verify the wallet has funds |
+| Claude status line does not update | Claude status line not set up yet | Run built-in `/statusline`, then add the wallet cache block |
 
 ## Related skills
 

--- a/skills/moonpay-wallet-statusline/SKILL.md
+++ b/skills/moonpay-wallet-statusline/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: moonpay-wallet-statusline
+description: >
+  Add wallet balances to the terminal status line. Use when the user asks to
+  "show balances in the status bar", "add wallet to status line", or wants a
+  persistent balance display while working.
+tags: [wallet, statusline]
+---
+
+# Wallet status line
+
+## Goal
+
+Display cached wallet balances in a terminal status line. Creates a config file, a refresh script, and a pre-rendered cache file that any status line can read.
+
+## Prerequisites
+
+- MoonPay CLI installed: `npm i -g @moonpay/cli`
+- Authenticated: `mp login` then `mp verify`
+- At least one wallet: `mp wallet list`
+- `jq` installed: `which jq`
+- `bc` installed (for USD totals): `which bc`
+
+## Commands
+
+```bash
+# List wallets
+mp wallet list
+
+# Fetch balances (used by the refresh script)
+mp --json wallet list
+mp --json bitcoin balance retrieve --wallet <btc-address>
+mp --json token balance list --wallet <address> --chain <chain>
+```
+
+## Supported chains
+
+`solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `optimism`, `bnb`, `avalanche`, `tron`, `bitcoin`, `ton`, `filecoin`
+
+Bitcoin uses a separate command (`mp bitcoin balance retrieve`) and does not return USD values.
+
+## Workflow
+
+### 1. Select wallets
+
+Run `mp wallet list` and ask the user which wallet(s) to track. For each wallet, ask which chains to display. Skip testnets/devnets by default (filter out chains containing "testnet", "devnet", "sepolia", "amoy", "tempo").
+
+### 2. Select display format
+
+- `amount` — symbol + balance (e.g., `BTC 0.00071`)
+- `amount+usd` — symbol + balance + USD (e.g., `mpSOL 0.00092 ($0.08)`). Bitcoin always shows amount only (no USD from the API).
+- `total+breakdown` — total USD + per-token (e.g., `$0.08 — mpSOL 0.00092`). Bitcoin balance is excluded from the USD total.
+
+### 3. Write config
+
+Save to `~/.config/moonpay/statusline.json`:
+
+```json
+{
+  "wallets": [
+    {
+      "name": "btc-wallet",
+      "chains": ["bitcoin", "solana"]
+    }
+  ],
+  "format": "amount"
+}
+```
+
+### 4. Create refresh script
+
+Write `~/.config/moonpay/refresh-statusline.sh` and make it executable (`chmod +x`). The script:
+
+1. Reads `~/.config/moonpay/statusline.json` for wallet names, chains, and format.
+2. Resolves wallet names to addresses via `mp --json wallet list`.
+3. Fetches balances per wallet+chain:
+   - Bitcoin: `mp --json bitcoin balance retrieve --wallet <addr>` — extracts `.total.btc`.
+   - Other chains: `mp --json token balance list --wallet <addr> --chain <chain>` — extracts `.items[].symbol`, `.items[].balance.amount`, `.items[].balance.value`.
+4. Formats output with ANSI colors:
+   - Token symbols in bold cyan (`\033[1;36m`), amounts in white (`\033[0;37m`), USD values in dim green (`\033[2;32m`).
+   - Tokens separated by dim ` | `.
+   - USD values rounded to 2 decimal places.
+   - Bitcoin uses the `₿` symbol; other tokens use the API-returned symbol.
+5. Writes the pre-rendered ANSI string to `~/.config/moonpay/statusline-cache.txt` using atomic write (temp file + `mv`).
+6. On error: keeps existing cache intact — never overwrites with empty or error output.
+7. If no balances found: removes the cache file.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG="$HOME/.config/moonpay/statusline.json"
+CACHE="$HOME/.config/moonpay/statusline-cache.txt"
+
+if [[ ! -f "$CONFIG" ]]; then exit 1; fi
+
+FORMAT=$(jq -r '.format // "amount"' "$CONFIG")
+# ... resolve wallets, fetch balances, format output, write cache
+# See moonpay-wallet-statusline-refresh skill for the refresh command
+```
+
+### 5. Run initial refresh
+
+```bash
+bash ~/.config/moonpay/refresh-statusline.sh
+```
+
+Verify the cache file was created:
+
+```bash
+cat ~/.config/moonpay/statusline-cache.txt
+```
+
+### 6. Confirm
+
+Tell the user:
+- The cache file is at `~/.config/moonpay/statusline-cache.txt`
+- Run `moonpay-wallet-statusline-refresh` to manually update balances
+- The agent-specific integration section below explains how to wire it into a status display
+
+## Agent-specific integration
+
+### Claude Code
+
+Add this block to `~/.claude/statusline-command.sh` (before the render section):
+
+```bash
+# ── Wallet balances ──────────────────────────────────────────────────────────
+wallet_str=""
+wallet_cache="$HOME/.config/moonpay/statusline-cache.txt"
+if [ -f "$wallet_cache" ]; then
+  wallet_str=$(cat "$wallet_cache")
+fi
+
+if [ -n "$wallet_str" ]; then
+  [ -n "$line3" ] && line3="${line3}${SEP}"
+  line3="${line3}${wallet_str}"
+fi
+```
+
+Optionally add a PostToolUse hook to `~/.claude/settings.json` to auto-refresh after fund-moving commands:
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "if": "Bash(mp token swap:*)|Bash(mp token send:*)|Bash(mp token bridge:*)|Bash(mp bitcoin send:*)|Bash(mp buy:*)",
+    "command": "bash ~/.config/moonpay/refresh-statusline.sh 2>/dev/null || true",
+    "async": true
+  }]
+}
+```
+
+### Other agents
+
+Any agent with a terminal status display can read the cache file:
+
+```bash
+cat ~/.config/moonpay/statusline-cache.txt
+```
+
+The cache contains a pre-rendered ANSI string. For plain text (no colors), strip ANSI codes:
+
+```bash
+sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
+```
+
+## Error handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `mp: command not found` | CLI not installed | `npm i -g @moonpay/cli` |
+| `jq: command not found` | jq not installed | Install via package manager |
+| `failed to list wallets` | Not authenticated | Run `mp login` then `mp verify` |
+| Empty cache after refresh | No balances on configured chains | Check config chains, verify wallet has funds |
+
+## Related skills
+
+- [moonpay-wallet-statusline-refresh](../moonpay-wallet-statusline-refresh/) — Manually refresh cached balances
+- [moonpay-auth](../moonpay-auth/) — Set up wallets if none exist
+- [moonpay-check-wallet](../moonpay-check-wallet/) — Detailed portfolio breakdown with allocation percentages

--- a/skills/moonpay-wallet-statusline/SKILL.md
+++ b/skills/moonpay-wallet-statusline/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: moonpay-wallet-statusline
 description: >
-  Show MoonPay wallet balances in the Claude Code status line using a local
+  Show MoonPay wallet balances in a compatible CLI status line using a local
   cache and refresh script. Use when the user asks to "show balances in the
-  status bar", "add wallet to Claude status line", or wants a persistent
+  status bar", "add wallet to the CLI status line", or wants a persistent
   balance display while working.
 tags: [wallet, statusline]
 ---
@@ -12,13 +12,13 @@ tags: [wallet, statusline]
 
 ## Goal
 
-Display cached MoonPay wallet balances in the Claude Code status line. This skill creates:
+Display cached MoonPay wallet balances in a compatible CLI status line. This skill creates:
 
 - `~/.config/moonpay/statusline.json` — tracked wallets, chains, and format
 - `~/.config/moonpay/refresh-statusline.sh` — refreshes balances from the MoonPay CLI
 - `~/.config/moonpay/statusline-cache.txt` — pre-rendered ANSI output for the status line
 
-Any other status display can also read the cache file directly.
+Any compatible status display can read the cache file directly.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ Any other status display can also read the cache file directly.
 - At least one wallet: `mp wallet list`
 - `jq` installed: `which jq`
 - `bc` installed: `which bc`
-- For Claude Code: the built-in status line setup has already been run, so `~/.claude/settings.json` has a `statusLine` config and `~/.claude/statusline.sh` exists
+- For status line integration: the target CLI supports a command-based status line or any equivalent scriptable status bar
 
 ## Commands
 
@@ -63,13 +63,19 @@ which jq
 which bc
 ```
 
-If the user wants Claude Code integration, also verify:
+If the user wants integration with a specific CLI, verify that CLI's status line entry point too.
+
+Examples:
 
 ```bash
+# Claude Code
 test -f ~/.claude/statusline.sh && echo "statusline script present"
+
+# Cursor CLI
+test -f ~/.cursor/statusline.sh && echo "cursor statusline script present"
 ```
 
-If `~/.claude/statusline.sh` is missing or Claude Code is not configured with a `statusLine`, tell the user to run the built-in `/statusline` command first, or configure `statusLine` manually in `~/.claude/settings.json`, then come back to this skill.
+If the target CLI does not yet have a status line configured, help the user set that up first, then come back to this skill.
 
 ### 2. Select wallet addresses and chains
 
@@ -311,7 +317,28 @@ For plain text:
 sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
 ```
 
-### 7. Wire into Claude Code
+### 7. Wire into a compatible CLI
+
+The generic pattern is:
+
+1. Find the status line script or inline command used by the target CLI
+2. Read `~/.config/moonpay/statusline-cache.txt`
+3. Append that cached output to the existing status line
+4. Preserve ANSI colors if the CLI supports them
+
+Any CLI that can run a script on status line render can use the cached output directly:
+
+```bash
+cat ~/.config/moonpay/statusline-cache.txt
+```
+
+If the target CLI does not support ANSI colors, strip them first:
+
+```bash
+sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
+```
+
+#### Claude Code example
 
 Add this block to `~/.claude/statusline.sh` before the final render/output section. Match the surrounding script style if variable names differ.
 
@@ -375,13 +402,40 @@ Optional on Claude Code v2.1.85+: add a `PostToolUse` hook to `~/.claude/setting
 }
 ```
 
+#### Cursor CLI example
+
+Cursor CLI uses `~/.cursor/cli-config.json` with a `statusLine.command` entry that typically points at `~/.cursor/statusline.sh`. Add the same cache-read pattern to that script, for example:
+
+```bash
+WALLET_CACHE="$HOME/.config/moonpay/statusline-cache.txt"
+WALLET_STR=""
+if [ -f "$WALLET_CACHE" ]; then
+  WALLET_STR="$(cat "$WALLET_CACHE")"
+fi
+
+if [ -n "$WALLET_STR" ]; then
+  [ -n "$LINE3" ] && LINE3="${LINE3}${SEP}"
+  LINE3="${LINE3}${WALLET_STR}"
+fi
+```
+
+If the user's script uses different variable names or a single-line layout, adapt the snippet to match the existing format.
+
+#### Other CLIs
+
+For any other CLI tool with a scriptable status line:
+
+- locate the script or command used for the status line
+- append `cat ~/.config/moonpay/statusline-cache.txt` or the ANSI-stripped variant
+- if the tool supports command hooks or post-command automation, wire `bash ~/.config/moonpay/refresh-statusline.sh` into that mechanism
+
 ### 8. Confirm
 
 Tell the user:
 
 - The cache file is `~/.config/moonpay/statusline-cache.txt`
 - Run `moonpay-wallet-statusline-refresh` to refresh manually
-- Changes appear in Claude Code on the next status line render or next session, depending on local setup
+- Changes appear in the target CLI on the next status line render or next session, depending on local setup
 
 ## Other agents
 
@@ -406,7 +460,7 @@ sed 's/\x1b\[[0-9;]*m//g' ~/.config/moonpay/statusline-cache.txt
 | `bc: command not found` | bc not installed | Install via package manager |
 | `mp verify` failed | Not authenticated or expired auth | Run `mp login` then `mp verify` |
 | Empty cache after refresh | No balances found on configured entries | Check configured addresses/chains and verify the wallet has funds |
-| Claude status line does not update | Claude status line not set up yet | Run built-in `/statusline`, then add the wallet cache block |
+| Status line does not update in the target CLI | CLI status line not set up yet or cache not wired in | Configure that CLI's status line first, then add the wallet cache block |
 
 ## Related skills
 


### PR DESCRIPTION
## New Skill

**Skill name:** `skills/moonpay-wallet-statusline/` and `skills/moonpay-wallet-statusline-refresh/`

**Description:** Adds MoonPay wallet status line skills for setting up a cached wallet balance display and manually refreshing that cached output from the MoonPay CLI.

**Primary chain:** Multi-chain (`solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `optimism`, `bnb`, `avalanche`, `tron`, `bitcoin`, `ton`, `filecoin`)

**Primary token:** Multi-token wallet balances

<img width="519" height="66" alt="image" src="https://github.com/user-attachments/assets/5128fc22-c1e7-424a-9e58-0807c93d8ccb" />


## Checklist

- [x] `skills/{name}/SKILL.md` with YAML frontmatter (`name`, `description`)
- [x] Skill added to `.claude-plugin/marketplace.json`
- [x] Description is specific about when Claude should trigger this skill

## MoonPay Integration

These skills use the MoonPay CLI (`mp`) plus MoonPay-owned config and cache files under `~/.config/moonpay/`.

- `moonpay-wallet-statusline` creates and documents:
  - `~/.config/moonpay/statusline.json`
  - `~/.config/moonpay/refresh-statusline.sh`
  - `~/.config/moonpay/statusline-cache.txt`
- `moonpay-wallet-statusline-refresh` reruns the refresh script and reports the cached status line output

## Example Usage

```bash
# Set up the cached wallet status line skill
Use `moonpay-wallet-statusline` when the user wants MoonPay balances in a CLI status line.

# Refresh the cached output after balances may have changed
Use `moonpay-wallet-statusline-refresh` when the user says "refresh balances" or after receiving funds from outside the CLI.
```

## Validation Notes

- Naming: uses the MoonPay-owned `moonpay-` prefix
- Frontmatter: both skills include `name`, `description`, and `tags`
- Marketplace placement: both skills are registered in the `moonpay-skills` plugin block
- Cross-references: links point to existing skills only
- Diff scope: PR only changes the two new skill files and `.claude-plugin/marketplace.json`
- Command review: documented `mp` commands and file paths were manually reviewed; this repo does not provide an automated test suite for skills