### PR TITLE
feat: add zyfai-yield skill — CLI-driven DeFi yield via Zyfai SDK

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,15 @@
         "./skills/moonpay-trading-automation",
         "./skills/moonpay-upgrade",
         "./skills/moonpay-virtual-account",
-        "./skills/moonpay-x402",
+        "./skills/moonpay-x402"
+      ]
+    },
+    {
+      "name": "zyfai-skills",
+      "description": "DeFi yield optimization on MoonPay wallets via Zyfai — automated multi-protocol yield across Base, Arbitrum, and Plasma",
+      "source": "./",
+      "strict": false,
+      "skills": [
         "./skills/zyfai-yield"
       ]
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,8 @@
         "./skills/moonpay-trading-automation",
         "./skills/moonpay-upgrade",
         "./skills/moonpay-virtual-account",
-        "./skills/moonpay-x402"
+        "./skills/moonpay-x402",
+        "./skills/zyfai-yield"
       ]
     }
   ]

--- a/skills/zyfai-yield/SKILL.md
+++ b/skills/zyfai-yield/SKILL.md
@@ -1,155 +1,133 @@
 ---
 name: zyfai-yield
 description: Earn DeFi yield on MoonPay wallets via Zyfai. Use when the user wants passive yield, automated DeFi returns, or to put idle funds to work on Base, Arbitrum, or Plasma.
-tags: [yield, defi]
+tags: [yield, defi, base, arbitrum, staking, usdc]
 ---
 
 # Zyfai — Earn Yield on MoonPay Wallets
 
 ## Overview
 
-Zyfai creates a non-custodial subaccount (Safe smart wallet) linked to the user's MoonPay wallet. Funds deposited into the subaccount are automatically optimized across DeFi protocols. The user stays in full control and can withdraw anytime.
+Zyfai creates a non-custodial subaccount (Safe smart wallet) linked to a MoonPay wallet. Deposited funds are automatically optimized across DeFi protocols. The user stays in full control and can withdraw anytime.
+
+Supported chains: **Base** (8453), **Arbitrum** (42161), **Plasma** (9745)
 
 ## Prerequisites
 
-- MoonPay CLI installed (`npm i -g @moonpay/cli`)
-- Authenticated (`mp login` → `mp verify`)
-- Funded wallet on Base, Arbitrum, or Plasma
-- Zyfai API key (create programmatically or at [sdk.zyf.ai](https://sdk.zyf.ai))
-- Node.js 18+ with `@zyfai/sdk` and `ethers` installed
+- MoonPay CLI: `npm i -g @moonpay/cli` — authenticated (`mp login`)
+- Node.js 18+
+- Zyfai SDK: `npm i -g @zyfai/sdk ethers`
+- Zyfai API key (see Step 1 below)
+- Helper scripts installed (see Installation)
 
-## Commands
+## Installation
 
 ```bash
-# Export MoonPay wallet mnemonic
-mp wallet export --wallet <wallet-name>
+# Install helper scripts from the Zyfai skill directory
+git clone https://github.com/ondefy/zyfai-sdk-demo.git ~/.zyfai-scripts
+npm install --prefix ~/.zyfai-scripts
+```
 
-# Check wallet balance before depositing
-mp token balance list --wallet <address> --chain base
+Or install from this skill's `scripts/` directory:
+
+```bash
+npm install --prefix ./skills/zyfai-yield/scripts @zyfai/sdk ethers
 ```
 
 ## Workflow
 
-1. Export the MoonPay wallet mnemonic with `mp wallet export --wallet <name>`
-2. Derive the address and private key from the mnemonic using ethers
-3. Create a Zyfai API key using the derived wallet address
-4. Connect to Zyfai SDK and deploy a subaccount
-5. Enable session key for automated yield optimization
-6. Deposit funds (USDC or WETH)
-7. Withdraw anytime back to the MoonPay wallet
+### Step 1 — Create a Zyfai API key
 
-## Example
-
-### Step 1: Export MoonPay wallet and derive keys
+Export your MoonPay wallet address, then create an API key tied to it:
 
 ```bash
-mp wallet export --wallet zyfai-base
+mp wallet retrieve --wallet <wallet-name>
+# Note the wallet address from the output
 ```
-
-```typescript
-import { HDNodeWallet } from "ethers";
-
-const mnemonic = "<mnemonic-from-moonpay>";
-const wallet = HDNodeWallet.fromPhrase(mnemonic);
-console.log("Address:", wallet.address);       // Use this to create API key
-console.log("Private Key:", wallet.privateKey); // Use this to connect SDK
-```
-
-### Step 2: Create Zyfai API key
-
-Use the wallet address from Step 1 to create your API key:
 
 ```bash
 curl -X POST https://sdk.zyf.ai/api/sdk-api-keys/create \
   -H "Content-Type: application/json" \
   -d '{
     "clientName": "moonpay-agent",
-    "walletAddress": "<address-from-step-1>",
+    "walletAddress": "<address-from-above>",
     "email": "agent@example.com"
   }'
+# Response: { "data": { "apiKey": "zyfai_..." } }
 ```
 
-Response:
-```json
-{
-  "success": true,
-  "data": {
-    "apiKey": "zyfai_361ad41d083c2fe.....",
-    "clientName": "moonpay-agent",
-    "ownerWalletAddress": "0x..."
-  }
-}
+Store the API key:
+
+```bash
+export ZYFAI_API_KEY="zyfai_..."
 ```
 
-> Store the `apiKey` securely — it cannot be retrieved later.
+### Step 2 — Export MoonPay wallet private key
 
-### Step 3: Deploy and deposit
-
-```typescript
-import { ZyfaiSDK } from "@zyfai/sdk";
-
-const sdk = new ZyfaiSDK({ apiKey: "<your-api-key>" });
-await sdk.connectAccount("<private-key>", 8453); // Base
-
-const userAddress = "<wallet-address>";
-
-// Deploy subaccount if needed
-const wallet = await sdk.getSmartWalletAddress(userAddress, 8453);
-if (!wallet.isDeployed) {
-  await sdk.deploySafe(userAddress, 8453, "conservative");
-}
-
-// Enable automated optimization
-await sdk.createSessionKey(userAddress, 8453);
-
-// Deposit 10 USDC (6 decimals)
-await sdk.depositFunds(userAddress, 8453, "10000000");
-
-// Or deposit 0.5 WETH (18 decimals) — user must have WETH, not ETH
-await sdk.depositFunds(userAddress, 8453, "500000000000000000", "WETH");
-
-await sdk.disconnectAccount();
+```bash
+mp wallet export --wallet <wallet-name>
+# Outputs mnemonic — derive private key with: node -e "const {HDNodeWallet}=require('ethers'); console.log(HDNodeWallet.fromPhrase('<mnemonic>').privateKey)"
 ```
 
-### Step 4: Withdraw
+Store for script use:
 
-```typescript
-await sdk.connectAccount("<private-key>", 8453);
+```bash
+export WALLET_PRIVATE_KEY="0x..."
+```
 
-// Withdraw all USDC (default)
-await sdk.withdrawFunds("<user-address>", 8453);
+### Step 3 — Deploy subaccount and enable yield
 
-// Partial USDC withdrawal (5 USDC)
-await sdk.withdrawFunds("<user-address>", 8453, "5000000");
+```bash
+# Deploy Safe subaccount + enable session key for automated optimization
+# Strategies: conservative (stable, lower risk) | aggressive (higher yield, higher risk)
+node ~/.zyfai-scripts/scripts/zyfai-deploy.js $WALLET_PRIVATE_KEY 8453 conservative
+```
 
-// Withdraw all WETH
-await sdk.withdrawFunds("<user-address>", 8453, undefined, "WETH");
+### Step 4 — Check wallet balance before depositing
 
-await sdk.disconnectAccount();
+```bash
+mp token balance list --wallet <address> --chain base
+```
+
+### Step 5 — Deposit funds
+
+```bash
+# Deposit 100 USDC on Base
+node ~/.zyfai-scripts/scripts/zyfai-deposit.js $WALLET_PRIVATE_KEY 8453 100 USDC
+
+# Deposit 0.5 WETH on Base (must have WETH, not ETH)
+node ~/.zyfai-scripts/scripts/zyfai-deposit.js $WALLET_PRIVATE_KEY 8453 0.5 WETH
+```
+
+### Step 6 — Withdraw (anytime)
+
+```bash
+# Withdraw all USDC
+node ~/.zyfai-scripts/scripts/zyfai-withdraw.js $WALLET_PRIVATE_KEY 8453
+
+# Partial withdrawal: 50 USDC
+node ~/.zyfai-scripts/scripts/zyfai-withdraw.js $WALLET_PRIVATE_KEY 8453 50 USDC
 ```
 
 ## Supported Chains
 
-| Chain    | ID    |
-|----------|-------|
-| Base     | 8453  |
-| Arbitrum | 42161 |
-| Plasma   | 9745  |
+| Chain    | Chain ID |
+|----------|----------|
+| Base     | 8453     |
+| Arbitrum | 42161    |
+| Plasma   | 9745     |
 
-## Strategies
+## Error Handling
 
-- `"conservative"` — Stable yield, lower risk
-- `"aggressive"` — Higher yield, higher risk
-
-## Resources
-
-- **API Key:** [sdk.zyf.ai](https://sdk.zyf.ai)
-- **Docs:** [docs.zyf.ai](https://docs.zyf.ai)
-- **SDK Demo:** [github.com/ondefy/zyfai-sdk-demo](https://github.com/ondefy/zyfai-sdk-demo)
-- **Zyfai Skill:** [zyf.ai/skill.md](https://zyf.ai/skill.md)
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Missing ZYFAI_API_KEY` | Env var not set | `export ZYFAI_API_KEY=...` |
+| `Subaccount already deployed` | Deploy ran twice | Normal — skip to deposit |
+| `Insufficient balance` | Not enough USDC/WETH | Fund via `moonpay-buy-crypto` |
+| `mp wallet export` fails | Not authenticated | Run `mp login` first |
 
 ## Related Skills
 
 - [moonpay-auth](../moonpay-auth/) — Set up and authenticate MoonPay wallets
-- [moonpay-check-wallet](../moonpay-check-wallet/) — Check wallet balances before depositing
+- [moonpay-check-wallet](../moonpay-check-wallet/) — Check balances before depositing
 - [moonpay-buy-crypto](../moonpay-buy-crypto/) — Fund wallet with fiat before earning yield

--- a/skills/zyfai-yield/SKILL.md
+++ b/skills/zyfai-yield/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: zyfai-yield
+description: Earn DeFi yield on MoonPay wallets via Zyfai. Use when the user wants passive yield, automated DeFi returns, or to put idle funds to work on Base, Arbitrum, or Plasma.
+tags: [yield, defi]
+---
+
+# Zyfai — Earn Yield on MoonPay Wallets
+
+## Overview
+
+Zyfai creates a non-custodial subaccount (Safe smart wallet) linked to the user's MoonPay wallet. Funds deposited into the subaccount are automatically optimized across DeFi protocols. The user stays in full control and can withdraw anytime.
+
+## Prerequisites
+
+- MoonPay CLI installed (`npm i -g @moonpay/cli`)
+- Authenticated (`mp login` → `mp verify`)
+- Funded wallet on Base, Arbitrum, or Plasma
+- Zyfai API key (create programmatically or at [sdk.zyf.ai](https://sdk.zyf.ai))
+- Node.js 18+ with `@zyfai/sdk` and `ethers` installed
+
+## Commands
+
+```bash
+# Export MoonPay wallet mnemonic
+mp wallet export --wallet <wallet-name>
+
+# Check wallet balance before depositing
+mp token balance list --wallet <address> --chain base
+```
+
+## Workflow
+
+1. Export the MoonPay wallet mnemonic with `mp wallet export --wallet <name>`
+2. Derive the address and private key from the mnemonic using ethers
+3. Create a Zyfai API key using the derived wallet address
+4. Connect to Zyfai SDK and deploy a subaccount
+5. Enable session key for automated yield optimization
+6. Deposit funds (USDC or WETH)
+7. Withdraw anytime back to the MoonPay wallet
+
+## Example
+
+### Step 1: Export MoonPay wallet and derive keys
+
+```bash
+mp wallet export --wallet zyfai-base
+```
+
+```typescript
+import { HDNodeWallet } from "ethers";
+
+const mnemonic = "<mnemonic-from-moonpay>";
+const wallet = HDNodeWallet.fromPhrase(mnemonic);
+console.log("Address:", wallet.address);       // Use this to create API key
+console.log("Private Key:", wallet.privateKey); // Use this to connect SDK
+```
+
+### Step 2: Create Zyfai API key
+
+Use the wallet address from Step 1 to create your API key:
+
+```bash
+curl -X POST https://sdk.zyf.ai/api/sdk-api-keys/create \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientName": "moonpay-agent",
+    "walletAddress": "<address-from-step-1>",
+    "email": "agent@example.com"
+  }'
+```
+
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "apiKey": "zyfai_361ad41d083c2fe.....",
+    "clientName": "moonpay-agent",
+    "ownerWalletAddress": "0x..."
+  }
+}
+```
+
+> Store the `apiKey` securely — it cannot be retrieved later.
+
+### Step 3: Deploy and deposit
+
+```typescript
+import { ZyfaiSDK } from "@zyfai/sdk";
+
+const sdk = new ZyfaiSDK({ apiKey: "<your-api-key>" });
+await sdk.connectAccount("<private-key>", 8453); // Base
+
+const userAddress = "<wallet-address>";
+
+// Deploy subaccount if needed
+const wallet = await sdk.getSmartWalletAddress(userAddress, 8453);
+if (!wallet.isDeployed) {
+  await sdk.deploySafe(userAddress, 8453, "conservative");
+}
+
+// Enable automated optimization
+await sdk.createSessionKey(userAddress, 8453);
+
+// Deposit 10 USDC (6 decimals)
+await sdk.depositFunds(userAddress, 8453, "10000000");
+
+// Or deposit 0.5 WETH (18 decimals) — user must have WETH, not ETH
+await sdk.depositFunds(userAddress, 8453, "500000000000000000", "WETH");
+
+await sdk.disconnectAccount();
+```
+
+### Step 4: Withdraw
+
+```typescript
+await sdk.connectAccount("<private-key>", 8453);
+
+// Withdraw all USDC (default)
+await sdk.withdrawFunds("<user-address>", 8453);
+
+// Partial USDC withdrawal (5 USDC)
+await sdk.withdrawFunds("<user-address>", 8453, "5000000");
+
+// Withdraw all WETH
+await sdk.withdrawFunds("<user-address>", 8453, undefined, "WETH");
+
+await sdk.disconnectAccount();
+```
+
+## Supported Chains
+
+| Chain    | ID    |
+|----------|-------|
+| Base     | 8453  |
+| Arbitrum | 42161 |
+| Plasma   | 9745  |
+
+## Strategies
+
+- `"conservative"` — Stable yield, lower risk
+- `"aggressive"` — Higher yield, higher risk
+
+## Resources
+
+- **API Key:** [sdk.zyf.ai](https://sdk.zyf.ai)
+- **Docs:** [docs.zyf.ai](https://docs.zyf.ai)
+- **SDK Demo:** [github.com/ondefy/zyfai-sdk-demo](https://github.com/ondefy/zyfai-sdk-demo)
+- **Zyfai Skill:** [zyf.ai/skill.md](https://zyf.ai/skill.md)
+
+## Related Skills
+
+- [moonpay-auth](../moonpay-auth/) — Set up and authenticate MoonPay wallets
+- [moonpay-check-wallet](../moonpay-check-wallet/) — Check wallet balances before depositing
+- [moonpay-buy-crypto](../moonpay-buy-crypto/) — Fund wallet with fiat before earning yield

--- a/skills/zyfai-yield/scripts/zyfai-deploy.js
+++ b/skills/zyfai-yield/scripts/zyfai-deploy.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Deploy Zyfai subaccount and enable session key for automated yield
+// Usage: node zyfai-deploy.js <privateKey> <chainId> [strategy]
+// chainId: 8453 (Base), 42161 (Arbitrum), 9745 (Plasma)
+// strategy: conservative (default) | aggressive
+const { ZyfaiSDK } = require("@zyfai/sdk");
+const { HDNodeWallet, ethers } = require("ethers");
+
+const [,, privateKey, chainId = "8453", strategy = "conservative"] = process.argv;
+if (!privateKey) { console.error("Usage: node zyfai-deploy.js <privateKey> <chainId> [strategy]"); process.exit(1); }
+
+const chainIdNum = parseInt(chainId);
+const wallet = new ethers.Wallet(privateKey);
+const address = wallet.address;
+console.log("Address:", address, "| Chain:", chainIdNum, "| Strategy:", strategy);
+
+(async () => {
+  const sdk = new ZyfaiSDK({ apiKey: process.env.ZYFAI_API_KEY });
+  await sdk.connectAccount(privateKey, chainIdNum);
+  const info = await sdk.getSmartWalletAddress(address, chainIdNum);
+  if (!info.isDeployed) {
+    console.log("Deploying subaccount...");
+    await sdk.deploySafe(address, chainIdNum, strategy);
+    console.log("Deployed.");
+  } else {
+    console.log("Subaccount already deployed:", info.address);
+  }
+  console.log("Enabling session key...");
+  await sdk.createSessionKey(address, chainIdNum);
+  console.log("Done. Subaccount ready for yield optimization.");
+  await sdk.disconnectAccount();
+})().catch(e => { console.error(e.message); process.exit(1); });

--- a/skills/zyfai-yield/scripts/zyfai-deposit.js
+++ b/skills/zyfai-yield/scripts/zyfai-deposit.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Deposit funds into Zyfai subaccount
+// Usage: node zyfai-deposit.js <privateKey> <chainId> <amount> [token]
+// amount: human-readable (e.g. "100" = 100 USDC, "0.5" = 0.5 WETH)
+// token: USDC (default) | WETH
+const { ZyfaiSDK } = require("@zyfai/sdk");
+const { ethers } = require("ethers");
+
+const [,, privateKey, chainId = "8453", amount, token = "USDC"] = process.argv;
+if (!privateKey || !amount) { console.error("Usage: node zyfai-deposit.js <privateKey> <chainId> <amount> [USDC|WETH]"); process.exit(1); }
+
+const decimals = token === "WETH" ? 18 : 6;
+const rawAmount = ethers.parseUnits(amount, decimals).toString();
+const chainIdNum = parseInt(chainId);
+const wallet = new ethers.Wallet(privateKey);
+
+(async () => {
+  const sdk = new ZyfaiSDK({ apiKey: process.env.ZYFAI_API_KEY });
+  await sdk.connectAccount(privateKey, chainIdNum);
+  console.log(`Depositing ${amount} ${token} (${rawAmount} raw) on chain ${chainIdNum}...`);
+  await sdk.depositFunds(wallet.address, chainIdNum, rawAmount, token === "USDC" ? undefined : token);
+  console.log("Deposit complete.");
+  await sdk.disconnectAccount();
+})().catch(e => { console.error(e.message); process.exit(1); });

--- a/skills/zyfai-yield/scripts/zyfai-withdraw.js
+++ b/skills/zyfai-yield/scripts/zyfai-withdraw.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Withdraw funds from Zyfai subaccount back to your wallet
+// Usage: node zyfai-withdraw.js <privateKey> <chainId> [amount] [token]
+// Omit amount to withdraw all. token: USDC (default) | WETH
+const { ZyfaiSDK } = require("@zyfai/sdk");
+const { ethers } = require("ethers");
+
+const [,, privateKey, chainId = "8453", amount, token = "USDC"] = process.argv;
+if (!privateKey) { console.error("Usage: node zyfai-withdraw.js <privateKey> <chainId> [amount] [USDC|WETH]"); process.exit(1); }
+
+const chainIdNum = parseInt(chainId);
+const wallet = new ethers.Wallet(privateKey);
+const decimals = token === "WETH" ? 18 : 6;
+const rawAmount = amount ? ethers.parseUnits(amount, decimals).toString() : undefined;
+
+(async () => {
+  const sdk = new ZyfaiSDK({ apiKey: process.env.ZYFAI_API_KEY });
+  await sdk.connectAccount(privateKey, chainIdNum);
+  const label = amount ? `${amount} ${token}` : `all ${token}`;
+  console.log(`Withdrawing ${label} on chain ${chainIdNum}...`);
+  await sdk.withdrawFunds(wallet.address, chainIdNum, rawAmount, token === "USDC" ? undefined : token);
+  console.log("Withdrawal complete.");
+  await sdk.disconnectAccount();
+})().catch(e => { console.error(e.message); process.exit(1); });


### PR DESCRIPTION
Supersedes the pending fixes from PR #12 which the original contributor hasn't applied.

## Changes
- **SKILL.md fully rewritten** — no inline TypeScript. All SDK operations called via `node scripts/zyfai-*.js` (shell-executable)
- **3 helper scripts added**: `scripts/zyfai-deploy.js`, `zyfai-deposit.js`, `zyfai-withdraw.js` — wraps `@zyfai/sdk` with clean CLI interfaces  
- **`zyfai-yield` moved to own `zyfai-skills` plugin block** in `marketplace.json`
- **Added Error Handling section** and expanded tags
- **PR title** corrected to `feat:` as requested

All verified items from Kevin's review preserved: `@zyfai/sdk` real, API endpoint real, cross-references valid.