### PR TITLE
fix(skills): repair stale CLI flag references (mirror of cli#465)

### DIFF
--- a/skills/moonpay-discover-tokens/SKILL.md
+++ b/skills/moonpay-discover-tokens/SKILL.md
@@ -20,7 +20,7 @@ mp token search --query "BONK" --chain solana
 mp token retrieve --token <mint-address> --chain solana
 
 # See what's trending
-mp token trending list --chain solana
+mp token trending list --chain solana --limit 5 --page 1
 ```
 
 ## Supported chains

--- a/skills/moonpay-export-data/SKILL.md
+++ b/skills/moonpay-export-data/SKILL.md
@@ -52,22 +52,24 @@ Note: EVM wallets share one address across all EVM chains. Solana uses a differe
 Export swap and bridge history. These are transactions executed via the CLI and registered with swaps.xyz — not all on-chain activity.
 
 ```bash
-echo "date,type,from_chain,from_token,from_amount,to_chain,to_token,to_amount,usd,status" \
-  > ~/Documents/moonpay/transactions-$(date +%Y%m%d).csv
+FILE=~/Documents/moonpay/transactions-$(date +%Y%m%d).csv
+echo "date,type,from_chain,from_token,from_amount,to_chain,to_token,to_amount,usd,status" > "$FILE"
 
-mp --json transaction list --wallet <address> \
-  | jq -r '.items[] | [
-      .transactionId,
-      .type,
-      .from.chain, .from.token, .from.amount,
-      .to.chain, .to.token, .to.amount,
-      .usd,
-      .status
-    ] | @csv' \
-  >> ~/Documents/moonpay/transactions-$(date +%Y%m%d).csv
+for CHAIN in solana ethereum base polygon arbitrum; do
+  mp --json transaction list --wallet <address> --chain "$CHAIN" \
+    | jq -r '.items[] | [
+        .transactionId,
+        .type,
+        .from.chain, .from.token, .from.amount,
+        .to.chain, .to.token, .to.amount,
+        .usd,
+        .status
+      ] | @csv' \
+    >> "$FILE" 2>/dev/null
+done
 ```
 
-### Filter by chain
+### Single chain only
 
 ```bash
 mp --json transaction list --wallet <address> --chain solana \


### PR DESCRIPTION
Mirrors the two CLI-flag fixes that just landed in moonpay/moonpay-cli#465 onto the public skills catalog.

## Why two repos
This repo and moonpay-cli's bundled `src/content/skills-manifest.json` carry the same SKILL.md content; both need the fix.

## Changes

- **moonpay-discover-tokens** — `mp token trending list` now requires `--limit` and `--page`. Added concrete values to every example.
- **moonpay-export-data** — `mp transaction list` now requires `--chain`. Replaced the single chain-less example with the per-chain loop the skill already uses for balance commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)