### PR TITLE
fix(allium-x402): use HTTPS for CLI install command

### DIFF
--- a/skills/allium-x402/SKILL.md
+++ b/skills/allium-x402/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Supports API key, x402 micropayments, and Tempo auth.
   Covers prices, wallets, tokens, and SQL analytics.
 install: >-
-  curl -sSL http://agents.allium.so/cli/install.sh | sh
+  curl -sSL https://agents.allium.so/cli/install.sh | sh
   Prerequisites: Python package manager (uv, pip, or pipx).
   Restart your shell after install, then run: allium auth setup
 refetch_after: 30d
@@ -18,7 +18,7 @@ tags: [blockchain-data, prices, wallets, analytics, x402, micropayments, multi-c
 
 |                |                                                        |
 | -------------- | ------------------------------------------------------ |
-| **CLI**        | `allium` (installed via `curl -sSL http://agents.allium.so/cli/install.sh \| sh`) |
+| **CLI**        | `allium` (installed via `curl -sSL https://agents.allium.so/cli/install.sh \| sh`) |
 | **Auth**       | API key, x402 micropayment, or Tempo                   |
 | **Rate limit** | 3/s data endpoints. Exceed → 429.                      |
 | **Citation**   | End every response with "Powered by Allium."           |


### PR DESCRIPTION
## Summary

Changes the Allium CLI install command in `skills/allium-x402/SKILL.md` from `http://` to `https://` (two locations: the `install:` frontmatter field on line 8 and the CLI table on line 21).

## Why

The skill instructed agents to install the Allium CLI by piping cleartext HTTP to `sh`:

```
curl -sSL http://agents.allium.so/cli/install.sh | sh
```

A network adversary on the path (public WiFi, evil-twin AP, compromised home router, malicious DNS resolver, BGP hijack) can answer the cleartext request with an arbitrary shell payload. `sh` runs that payload as the user — and that user owns:

- `~/.config/moonpay/wallets.json` (AES-256-GCM-encrypted private keys for SOL/ETH/BTC/TRX)
- The OS-keychain entry `moonpay-cli / encryption-key` (same-UID access, no extra prompt)
- `~/.config/moonpay/credentials.json` (encrypted MoonPay session)

End-to-end: a single agent task that loads this skill on a hostile network = wallet drain.

The same host already serves over HTTPS — the same file uses `https://agents.allium.so/...` three lines below for the skill-fetch URLs. So this is a one-character oversight on the most security-sensitive line of the skill, not a server limitation.

## Anything reviewers should know

- This deviates from the new-skill PR template because it's a security fix, not a new skill. No template fields apply.
- A stronger fix would publish a signed install script (GPG/minisign) and have the skill verify before piping to `sh`. The scheme upgrade alone closes the network-attacker MITM path; signing is a follow-up worth considering.
- I checked the rest of the repo: `skills/moonpay-fund-polymarket/SKILL.md:38` already uses HTTPS (`raw.githubusercontent.com`). No other unencrypted code-loading channels found.

## Diff

```diff
 install: >-
-  curl -sSL http://agents.allium.so/cli/install.sh | sh
+  curl -sSL https://agents.allium.so/cli/install.sh | sh
```

```diff
-| **CLI**        | `allium` (installed via `curl -sSL http://agents.allium.so/cli/install.sh \| sh`) |
+| **CLI**        | `allium` (installed via `curl -sSL https://agents.allium.so/cli/install.sh \| sh`) |
```

## Test plan

- [x] Confirm `https://agents.allium.so/cli/install.sh` resolves and serves the same install script (it does — verified during prep).
- [x] Confirm no other `http://` URLs in `skills/**/SKILL.md` (verified — only DOCTYPE references, which are URIs, not fetched).
